### PR TITLE
rilmodem/call-volume: Fix parsing of SET_MUTE reply.

### DIFF
--- a/drivers/rilmodem/call-volume.c
+++ b/drivers/rilmodem/call-volume.c
@@ -111,6 +111,9 @@ static void probe_mute_cb(struct ril_msg *message, gpointer user_data)
 	}
 
 	ril_util_init_parcel(message, &rilp);
+
+	/* skip length of int[] */
+	parcel_r_int32(&rilp);
 	muted = parcel_r_int32(&rilp);
 
 	g_ril_append_print_buf(cvd->ril, "{%d}", muted);


### PR DESCRIPTION
Based on commit '47ef2123723f347994e34a8e70c1183e38c3ce97' from
branch 'master' of https://github.com/nemomobile-packages/ofono.

Original-Author: Jarko Poutiainen Jarko.Poutiainen@oss.tieto.com
