### PR TITLE
Ensure that *netreg_data is always set in callback data (LP: 1234491).

### DIFF
--- a/drivers/rilmodem/network-registration.c
+++ b/drivers/rilmodem/network-registration.c
@@ -384,6 +384,8 @@ static void ril_register_auto(struct ofono_netreg *netreg,
 	struct cb_data *cbd = cb_data_new(cb, data);
 	int request = RIL_REQUEST_SET_NETWORK_SELECTION_AUTOMATIC;
 	int ret;
+
+	/* add *netreg_data to callback */
 	cbd->user = nd;
 
 	ret = g_ril_send(nd->ril, request,
@@ -407,6 +409,9 @@ static void ril_register_manual(struct ofono_netreg *netreg,
 	struct parcel rilp;
 	int request = RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL;
 	int ret;
+
+	/* add *netreg_data to callback */
+	cbd->user = nd;
 
 	parcel_init(&rilp);
 


### PR DESCRIPTION
ril_register_auto() correctly set cdb->user, whereas
ril_register_manual() did not.  As both shared the same callback
function, ril_register_cb(), and this function always expected
cdb->user to be non-NULL, calls to register_manual() could
cause a segfault.
