### PR TITLE
Fix crash in ril_query_passwd_state() ( LP: 1231995 ).

### DIFF
--- a/drivers/rilmodem/sim.c
+++ b/drivers/rilmodem/sim.c
@@ -602,8 +602,8 @@ static void ril_query_passwd_state(struct ofono_sim *sim,
 
 	if (sd->passwd_state == OFONO_SIM_PASSWORD_INVALID)
 		CALLBACK_WITH_FAILURE(cb, -1, data);
-
-	CALLBACK_WITH_SUCCESS(cb, sd->passwd_state, data);
+	else
+		CALLBACK_WITH_SUCCESS(cb, sd->passwd_state, data);
 }
 
 static void ril_pin_change_state_cb(struct ril_msg *message, gpointer user_data)


### PR DESCRIPTION
A missing 'else' statement meant that if 'passwd_state'
was invalid, both CALLBACK_WITH_FAILURE _and_ _WITH_SUCCESS
are called, which leads to failure as the "-1" passed to
the SUCCESS callback causes a segfault, as "-1" doesn't
map to valid enum, which is used to set a DBus string
property.
