### PR TITLE
rilmodem: Fix for memory leaks

### DIFF
--- a/drivers/rilmodem/gprs.c
+++ b/drivers/rilmodem/gprs.c
@@ -137,8 +137,6 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 	gboolean notify_status = FALSE;
 	int old_status;
 
-	DBG("");
-
 	if (message->error != RIL_E_SUCCESS) {
 		ofono_error("%s: DATA_REGISTRATION_STATE reply failure: %s",
 				__func__,
@@ -215,6 +213,8 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 		 * This callback is a result of the inital call
 		 * to probe(), so should return after registration.
 		 */
+		g_free(reply);
+
 		return;
 	}
 

--- a/drivers/rilmodem/sim.c
+++ b/drivers/rilmodem/sim.c
@@ -405,6 +405,8 @@ static void configure_active_app(struct sim_data *sd,
 					struct reply_sim_app *app,
 					guint index)
 {
+	g_free(sd->aid_str);
+	g_free(sd->app_str);
 	sd->app_type = app->app_type;
 	sd->aid_str = g_strdup(app->aid_str);
 	sd->app_str = g_strdup(app->app_str);
@@ -803,6 +805,8 @@ static void ril_sim_remove(struct ofono_sim *sim)
 	ofono_sim_set_data(sim, NULL);
 
 	g_ril_unref(sd->ril);
+	g_free(sd->aid_str);
+	g_free(sd->app_str);
 	g_free(sd);
 }
 


### PR DESCRIPTION
This change fixes memory leaks returned by valgrind.
