### PR TITLE
rilmodem: default gprs max_cids to 1

### DIFF
--- a/drivers/rilmodem/gprs.c
+++ b/drivers/rilmodem/gprs.c
@@ -205,11 +205,13 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 				RIL_UNSOL_RESPONSE_VOICE_NETWORK_STATE_CHANGED,
 				ril_gprs_state_change, gprs);
 
-		if (reply->max_cids > gd->max_cids) {
-			DBG("Setting max cids to %d", reply->max_cids);
+		if (reply->max_cids)
 			gd->max_cids = reply->max_cids;
-			ofono_gprs_set_cid_range(gprs, 1, reply->max_cids);
-		}
+		else
+			gd->max_cids = 1;
+
+		DBG("Setting max cids to %d", gd->max_cids);
+		ofono_gprs_set_cid_range(gprs, 1, gd->max_cids);
 
 		/*
 		 * This callback is a result of the inital call


### PR DESCRIPTION
Some rild implementations ( eg. maguro ) don't always return
a value for max_cids in a reply to a DATA_REGISTRATION request.
Ensure that the sensible default of 1 is used.

Tested on maguro running system image #10.
