### PR TITLE
test: add rilmodem specific tests

### DIFF
--- a/test/rilmodem/test-hangup
+++ b/test/rilmodem/test-hangup
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+#
+#
+# This test ensures that basic modem information is available
+# when the modem is online and has a valid, unlocked SIM present.
+#
+# *** REQUIRED SETUP ***
+#
+# 1. /etc/host:
+# This script uses telnetlib to access the emulator console.  In
+# order for this to work, the emulator needs to be configured so
+# that it can access 'localhost' on the host machine.  This is 
+# done by modifying /etc/hosts in the emulator to define 'localhost'
+# as 10.0.2.2, which is a special alias to the host loopback interface.
+# Without this change, it's impossible for this script to access the
+# emulator console.
+#
+# 2. Modem online
+# This script must be run *after* the modem has been brought online,
+# otherwise it will fail.  This is currently done by telepathy-ofono,
+# which isn't being started in the current touch emulator, however it
+# will soon be the responsibility of urfkill.
+#
+#  *** TODO ***
+#
+# 1. This test calls HangupAll() which is an asynchronous operation.
+# There's no getting around that fact that a timer needs to be used
+# to delay querying the calls after the hangup.  The code currently
+# uses a time.sleep(5), however it could be changed to list for a
+# CallRemoved signal.  A timer would still be required to catch the
+# scenario where the signal was never received.
+#
+# 2. Implement signal handler in case time.sleep() is interruped by
+# by a signal.
+#
+
+import dbus
+import sys
+import time
+import telnetlib
+
+def create_incoming_call(number, port):
+
+    tn = telnetlib.Telnet("localhost", 5554)
+    tn.read_until("OK")
+
+    tn.write("gsm call " + number + "\n")
+    print "incoming call created"
+
+    tn.read_until("OK")
+    tn.write("exit")
+
+if __name__ == "__main__":
+
+    if len(sys.argv) == 2:
+       port = sys.argv[1]
+    else:
+        port = 5554
+
+    create_incoming_call("6663334444", port)
+
+    bus = dbus.SystemBus()
+
+    manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+						'org.ofono.Manager')
+    modems = manager.GetModems()
+
+    for path, properties in modems:
+	print "[ %s ]" % (path)
+
+	assert "org.ofono.VoiceCallManager" in properties["Interfaces"]
+
+	mgr = dbus.Interface(bus.get_object('org.ofono', path),
+					'org.ofono.VoiceCallManager')
+	calls = mgr.GetCalls()
+
+        assert len(calls) > 0, "No incoming call present!"
+
+        mgr.HangupAll()
+
+        time.sleep(5)
+
+	calls = mgr.GetCalls()
+
+        assert len(calls) == 0, "HangupAll() failed, calls still exist!"

--- a/test/rilmodem/test-modem-offline
+++ b/test/rilmodem/test-modem-offline
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+#
+#
+# This test ensures that basic modem information is available
+# when the modem is offline.
+
+import dbus
+
+bus = dbus.SystemBus()
+
+manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+						'org.ofono.Manager')
+
+modems = manager.GetModems()
+
+for path, properties in modems:
+	print "[ %s ]" % (path)
+
+	keys = properties.keys()
+
+	assert keys.index('Online') != "ValueError"
+	assert keys.index("Powered") != "ValueError"
+	assert keys.index("Emergency") != "ValueError"
+	assert keys.index("Lockdown") != "ValueError"
+	assert keys.index("Serial") != "ValueError"
+	assert keys.index("Revision") != "ValueError"
+	assert keys.index("Interfaces") != "ValueError"
+
+	assert properties['Online'] == 0
+	assert properties['Powered'] == 1
+	assert properties['Emergency'] == 0
+	assert properties["Lockdown"] == 0
+	assert properties["Serial"].isalnum()
+	assert properties["Revision"].isalnum() 
+
+	print "OK\n"

--- a/test/rilmodem/test-sim-online
+++ b/test/rilmodem/test-sim-online
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+#
+#
+# This test ensures that basic modem information is available
+# when the modem is online and has a valid, unlocked SIM present.
+
+import dbus
+import time
+
+bus = dbus.SystemBus()
+
+manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+						'org.ofono.Manager')
+modems = manager.GetModems()
+path = modems[0][0]
+
+print "[ %s ]" % (path)
+
+print "Setting modem %s online..." % path
+modem = dbus.Interface(bus.get_object('org.ofono', path), 'org.ofono.Modem')
+modem.SetProperty("Online", dbus.Boolean(1), timeout = 120)
+
+time.sleep(5)
+
+properties = modem.GetProperties()
+keys = properties.keys()
+
+assert keys.index("Features") != 'ValueError'
+assert keys.index("Emergency") != 'ValueError'
+assert keys.index("Powered") != 'ValueError'
+assert keys.index("Lockdown") != 'ValueError'
+assert keys.index("Interfaces") != 'ValueError'
+assert keys.index('Online') != 'ValueError'
+assert keys.index('Model') != 'ValueError'
+
+# TODO: not properly set by emulator
+# assert keys.index("Revision") != 'ValueError'
+
+assert keys.index('Type') != 'ValueError'
+
+# TODO: not properly set by emulator
+#assert keys.index('Serial') != 'ValueError'
+
+assert keys.index('Manufacturer') != 'ValueError'
+
+# validate Features = net sms gprs sim
+
+assert properties['Emergency'] == 0
+assert properties['Powered'] == 1
+assert properties["Lockdown"] == 0
+
+# TODO: validate Interfaces: NetworkReg, CallVolume, MessageManager,
+#       ConnectionManager, NetworkTime, SimManager, VoiceCallManager
+
+assert properties['Online'] == 1
+assert properties['Model'] == "Fake Modem Model"
+assert properties['Type'] == "hardware"
+
+# TODO: not properly set by emulator
+#assert properties['Serial'] == "000000000000000"
+
+assert properties['Manufacturer'] == "Fake Manufacturer"
+
+# TODO: not properly set by emulator
+#assert properties["Revision"].isalnum() 
+
+# valid SimManager properties
+simmanager = dbus.Interface(bus.get_object('org.ofono', path),
+                            'org.ofono.SimManager')
+
+properties = simmanager.GetProperties()
+keys = properties.keys()
+
+assert keys.index('Retries') != 'ValueError'
+assert keys.index('FixedDialing') != 'ValueError'
+assert keys.index('MobileCountryCode') != 'ValueError'
+assert keys.index('SubscriberNumbers') != 'ValueError'
+assert keys.index('BarredDialing') != 'ValueError'
+assert keys.index('CardIdentifier') != 'ValueError'
+assert keys.index('LockedPins') != 'ValueError'
+assert keys.index('MobileNetworkCode') != 'ValueError'
+assert keys.index('SubscriberIdentity') != 'ValueError'
+assert keys.index('Present') != 'ValueError'
+assert keys.index('PinRequired') != 'ValueError'
+
+# TODO: Retries isn't currently populated ( lp: )
+# assert properties['Retries'] == 
+assert properties['FixedDialing'] == 0
+assert properties['MobileCountryCode'] == '310'
+assert properties['SubscriberNumbers'][0] == '15555215554'
+assert properties['BarredDialing'] == 0
+assert properties['CardIdentifier'] == '89014103211118510720'
+print '%s' % properties['LockedPins']
+assert len(properties['LockedPins']) == 0
+assert properties['MobileNetworkCode'] == '260'
+assert properties['SubscriberIdentity'] == '310260000000000'
+assert properties['Present'] == 1
+assert properties['PinRequired'] == "none"
+
+# valid NetworkRegistration properties
+netreg = dbus.Interface(bus.get_object('org.ofono', path),
+                            'org.ofono.NetworkRegistration')
+
+properties = netreg.GetProperties()
+keys = properties.keys()
+
+assert keys.index('Status') != 'ValueError'
+
+# TODO: no Strength reported by emulator!
+# assert keys.index('Strength') != 'ValueError'
+
+assert keys.index('Name') != 'ValueError'
+assert keys.index('LocationAreaCode') != 'ValueError'
+assert keys.index('Mode') != 'ValueError'
+assert keys.index('MobileCountryCode') != 'ValueError'
+
+# TODO: no Technology reported by emulator
+# assert keys.index('Technology') != 'ValueError'
+
+assert keys.index('CellId') != 'ValueError'
+assert keys.index('MobileNetworkCode') != 'ValueError'
+
+assert properties['Status'] == 'registered'
+assert properties['Name'] == 'Android (Android)'
+assert properties['LocationAreaCode'] == 65535
+
+# TODO: emulator reports 'Mode' as 'auto' ! 'auto-only'
+# assert properties['Mode'] == 'auto-only'
+
+assert properties['MobileCountryCode'] == '310'
+
+# TODO: no Technology reported by emulator
+# assert properties['Technology'] == 'umts'
+
+assert properties['MobileNetworkCode'] == '260'
+
+# valid VoiceCallManager properties
+voice = dbus.Interface(bus.get_object('org.ofono', path),
+                            'org.ofono.VoiceCallManager')
+
+properties = voice.GetProperties()
+keys = properties.keys()
+
+assert keys.index('EmergencyNumbers') != 'ValueError'
+
+numbers = properties['EmergencyNumbers']
+
+
+
+print "%s" % numbers
+
+for number in numbers:
+    assert number in ['08', '000', '999', '110', '112', '911', '118', '119']
+
+print "OK\n"


### PR DESCRIPTION
Add rilmodem directory and tests to be used both for
daily and CI testing.  Some of these tests are only
meant to be run within the touch emulator, as they
rely on the emulator console commands in order to
change the state of the mocked modem.
