### PR TITLE
idmap: use UL for bitshift literals (LP: #1271284)

### DIFF
--- a/src/idmap.c
+++ b/src/idmap.c
@@ -135,7 +135,7 @@ void idmap_put(struct idmap *idmap, unsigned int id)
 
 	id %= BITS_PER_LONG;
 
-	idmap->bits[offset] &= ~(1 << id);
+	idmap->bits[offset] &= ~(1UL << id);
 }
 
 unsigned int idmap_alloc(struct idmap *idmap)
@@ -149,7 +149,7 @@ unsigned int idmap_alloc(struct idmap *idmap)
 		return idmap->max + 1;
 
 	offset = bit / BITS_PER_LONG;
-	idmap->bits[offset] |= 1 << (bit % BITS_PER_LONG);
+	idmap->bits[offset] |= 1UL << (bit % BITS_PER_LONG);
 
 	return bit + idmap->min;
 }
@@ -163,7 +163,7 @@ void idmap_take(struct idmap *idmap, unsigned int id)
 		return;
 
 	offset = bit / BITS_PER_LONG;
-	idmap->bits[offset] |= 1 << (bit % BITS_PER_LONG);
+	idmap->bits[offset] |= 1UL << (bit % BITS_PER_LONG);
 }
 
 /*
@@ -186,7 +186,7 @@ unsigned int idmap_alloc_next(struct idmap *idmap, unsigned int last)
 		return idmap_alloc(idmap);
 
 	offset = bit / BITS_PER_LONG;
-	idmap->bits[offset] |= 1 << (bit % BITS_PER_LONG);
+	idmap->bits[offset] |= 1UL << (bit % BITS_PER_LONG);
 
 	return bit + idmap->min;
 }


### PR DESCRIPTION
The current bitshift logic in idmap incorrectly uses
the literal 1 for the value to shift in idmap_alloc(),
idmap_take(), and idmap_alloc_next().  This causes the
resulting value to be an int instead of a long, which
results in the wrong bit being set once the number of
bits to shift operand exceeds sizeof(int).  Also
on some platforms, the behavior of the left bitshift
operator is undefined when this overflow occurs.

Sanity tested ( confirmed GPRS was active ) on maguro with build #144.
