### PR TITLE
test: add exception handling to some scripts

### DIFF
--- a/test/enable-modem
+++ b/test/enable-modem
@@ -8,8 +8,13 @@ bus = dbus.SystemBus()
 if len(sys.argv) == 2:
 	path = sys.argv[1]
 else:
-	manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+	try:
+		manager = dbus.Interface(bus.get_object('org.ofono', '/'),
 			'org.ofono.Manager')
+	except dbus.exceptions.DBusException as e:
+	       print ("Can't access org.ofono on DBus: {}".format(e))
+	       exit(1)
+
 	modems = manager.GetModems()
 	path = modems[0][0]
 
@@ -17,4 +22,8 @@ print("Connecting modem %s..." % path)
 modem = dbus.Interface(bus.get_object('org.ofono', path),
 						'org.ofono.Modem')
 
-modem.SetProperty("Powered", dbus.Boolean(1), timeout = 120)
+try:
+	modem.SetProperty("Powered", dbus.Boolean(1), timeout = 120)
+except dbus.exceptions.DBusException as e:
+	print("Can't set modem 'Powered': {}".format(e))
+	exit(1)

--- a/test/list-modems
+++ b/test/list-modems
@@ -4,8 +4,12 @@ import dbus
 
 bus = dbus.SystemBus()
 
-manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+try:
+	manager = dbus.Interface(bus.get_object('org.ofono', '/'),
 						'org.ofono.Manager')
+except dbus.exceptions.DBusException as e:
+       print("Service org.ofono not found on DBus: {}".format(e))
+       exit(1)
 
 modems = manager.GetModems()
 


### PR DESCRIPTION
Add exception handling to 'enable-modem' and 'list-modems',
so that they don't crash when ofono isn't running and/or
hasn't completely initialized.

Tested on mako running image #217.
