### PR TITLE
test: Switch scripts to run with Python 3

### DIFF
--- a/test/scan-for-operators
+++ b/test/scan-for-operators
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/send-sms
+++ b/test/send-sms
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/send-ussd
+++ b/test/send-ussd
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/send-vcal
+++ b/test/send-vcal
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/send-vcard
+++ b/test/send-vcard
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-call-forwarding
+++ b/test/set-call-forwarding
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 from gi.repository import GLib

--- a/test/set-cbs-topics
+++ b/test/set-cbs-topics
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-context-property
+++ b/test/set-context-property
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-fast-dormancy
+++ b/test/set-fast-dormancy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-gsm-band
+++ b/test/set-gsm-band
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-mic-volume
+++ b/test/set-mic-volume
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-mms-details
+++ b/test/set-mms-details
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-roaming-allowed
+++ b/test/set-roaming-allowed
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-speaker-volume
+++ b/test/set-speaker-volume
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/set-tech-preference
+++ b/test/set-tech-preference
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-tty
+++ b/test/set-tty
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-umts-band
+++ b/test/set-umts-band
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/set-use-sms-reports
+++ b/test/set-use-sms-reports
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys

--- a/test/swap-calls
+++ b/test/swap-calls
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/test-advice-of-charge
+++ b/test/test-advice-of-charge
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 import sys

--- a/test/test-call-barring
+++ b/test/test-call-barring
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 import sys

--- a/test/test-call-forwarding
+++ b/test/test-call-forwarding
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-call-settings
+++ b/test/test-call-settings
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-cbs
+++ b/test/test-cbs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import dbus.mainloop.glib

--- a/test/test-gnss
+++ b/test/test-gnss
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 import sys

--- a/test/test-message-waiting
+++ b/test/test-message-waiting
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 import sys

--- a/test/test-modem
+++ b/test/test-modem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-network-registration
+++ b/test/test-network-registration
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 import sys

--- a/test/test-phonebook
+++ b/test/test-phonebook
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus, sys
 

--- a/test/test-push-notification
+++ b/test/test-push-notification
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-smart-messaging
+++ b/test/test-smart-messaging
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-sms
+++ b/test/test-sms
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 from gi.repository import GLib

--- a/test/test-ss
+++ b/test/test-ss
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import dbus

--- a/test/test-ss-control-cb
+++ b/test/test-ss-control-cb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-ss-control-cf
+++ b/test/test-ss-control-cf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-ss-control-cs
+++ b/test/test-ss-control-cs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/test-stk-menu
+++ b/test/test-stk-menu
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from gi.repository import GLib
 

--- a/test/unlock-pin
+++ b/test/unlock-pin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import dbus
 import sys


### PR DESCRIPTION
For some reason, the initial commit for the switch to Python3 was truncated.  None of the scripts which followed those in the /rilmodem sub-directory were actually switched.
