### PR TITLE
unit: add missing endian ifdefs to test-gril*

### DIFF
--- a/unit/test-grilreply.c
+++ b/unit/test-grilreply.c
@@ -42,6 +42,14 @@
  * once more tests are added.
  */
 
+/*
+ * As all our architectures are little-endian except for
+ * PowerPC, and the Binder wire-format differs slightly
+ * depending on endian-ness, the following guards against test
+ * failures when run on PowerPC.
+ */
+#if BYTE_ORDER == LITTLE_ENDIAN
+
 typedef struct reg_state_test reg_state_test;
 struct reg_state_test {
 	int status;
@@ -49,6 +57,7 @@ struct reg_state_test {
 	const struct ril_msg msg;
 };
 
+typedef struct get_preferred_network_test get_preferred_network_test;
 struct get_preferred_network_test {
 	int preferred;
 	const struct ril_msg msg;
@@ -1484,7 +1493,7 @@ static const guchar reply_get_preferred_network_type_valid_parcel1[] = {
 	0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const struct get_preferred_network_test
+static const get_preferred_network_test
 		reply_get_preferred_network_type_valid_1 = {
 	.preferred = 0,
 	.msg = {
@@ -1707,12 +1716,13 @@ static void test_reply_get_clir_valid(gconstpointer data)
 
 static void test_reply_get_preferred_network_type_valid(gconstpointer data)
 {
-	const struct get_preferred_network_test *test = data;
+	const get_preferred_network_test *test = data;
 	int type =
 		g_ril_reply_parse_get_preferred_network_type(NULL, &test->msg);
 
 	g_assert(type == test->preferred);
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/unit/test-grilrequest.c
+++ b/unit/test-grilrequest.c
@@ -36,17 +36,25 @@
 
 #include "grilrequest.h"
 
-struct request_test_data {
-	gconstpointer request;
-	const guchar *parcel_data;
-	gsize parcel_size;
-};
-
 /*
  * TODO: It may make sense to split this file into
  * domain-specific files ( eg. test-grilrequest-gprs-context.c )
  * once more tests are added.
  */
+
+/*
+ * As all our architectures are little-endian except for
+ * PowerPC, and the Binder wire-format differs slightly
+ * depending on endian-ness, the following guards against test
+ * failures when run on PowerPC.
+ */
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+struct request_test_data {
+	gconstpointer request;
+	const guchar *parcel_data;
+	gsize parcel_size;
+};
 
 static const struct req_deactivate_data_call req_deact_data_call_invalid_1 = {
 	.cid = 1,
@@ -1152,6 +1160,7 @@ static void test_request_set_preferred_network_type(gconstpointer data)
 
 	parcel_free(&rilp);
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/unit/test-grilunsol.c
+++ b/unit/test-grilunsol.c
@@ -42,6 +42,14 @@
  * once more tests are added.
  */
 
+/*
+ * As all our architectures are little-endian except for
+ * PowerPC, and the Binder wire-format differs slightly
+ * depending on endian-ness, the following guards against test
+ * failures when run on PowerPC.
+ */
+#if BYTE_ORDER == LITTLE_ENDIAN
+
 typedef struct signal_strength_test signal_strength_test;
 struct signal_strength_test {
 	int strength;
@@ -303,6 +311,7 @@ static void test_unsol_on_ussd_valid(gconstpointer data)
 	g_assert(unsol != NULL);
 	g_ril_unsol_free_ussd(unsol);
 }
+#endif
 
 int main(int argc, char **argv)
 {
@@ -315,6 +324,7 @@ int main(int argc, char **argv)
  * failures when run on PowerPC.
  */
 #if BYTE_ORDER == LITTLE_ENDIAN
+
 	g_test_add_data_func("/testgrilunsol/gprs-context: "
 				"invalid DATA_CALL_LIST_CHANGED Test 1",
 				&unsol_data_call_list_changed_invalid_1,


### PR DESCRIPTION
Minor fixup of the endian checking ifdef code and ws formatting to sync up with the archive version of ofono:

lp:~phablet-team/ofono/ubuntu

No functional changes.
