### PR TITLE
Fix for LP#1269017 : Use UTF-16 instead of UCS-2 for SMS

### DIFF
--- a/src/smsutil.c
+++ b/src/smsutil.c
@@ -2289,11 +2289,10 @@ char *sms_decode_text(GSList *sms_list)
 			 * Header is odd, the maximum length of the whole TP-UD
 			 * field is 139 octets
 			 */
-			gssize num_ucs2_chars = (udl_in_bytes - taken) >> 1;
-			num_ucs2_chars = num_ucs2_chars << 1;
+			gssize num_octects = (udl_in_bytes - taken) & ~1u;
 
-			converted = g_convert(from, num_ucs2_chars,
-						"UTF-8//TRANSLIT", "UCS-2BE",
+			converted = g_convert(from, num_octects,
+						"UTF-8//TRANSLIT", "UTF-16BE",
 						NULL, NULL, NULL);
 		}
 
@@ -3561,7 +3560,7 @@ GSList *sms_text_prepare_with_alphabet(const char *to, const char *utf8,
 	if (gsm_encoded == NULL) {
 		gsize converted;
 
-		ucs2_encoded = g_convert(utf8, -1, "UCS-2BE//TRANSLIT", "UTF-8",
+		ucs2_encoded = g_convert(utf8, -1, "UTF-16BE//TRANSLIT", "UTF-8",
 						NULL, &converted, NULL);
 		written = converted;
 	}


### PR DESCRIPTION
Although UTF-16 is not mentioned in the 3gpp standards as a valid SMS coding, most smartphones use it instead of plain UCS-2 when UCS-2 is the encoding specified in the SMS header. This allows the phone to send characters out of the basic multiligual plane, like emojis. As these characters are codified using codes forbidden for UCS-2, all valid UCS-2 code points can still be sent.

To test receiving: Use a smartphone that can send emoticons in SMS, and try that. For instance, send Unicode code points 0x1F62E, 0x1F631 or 0x1F630.

To test sending, you can copy the output of a received message and send it back. For instance:
send-sms <number> "x😱x" 0
or similar
