### PR TITLE
plugins: fix android-provision crash

### DIFF
--- a/plugins/android-provision.c
+++ b/plugins/android-provision.c
@@ -138,6 +138,7 @@ static int provision_get_settings(const char *mcc, const char *mnc,
 					" mnc %s spn %s imsi %s", __func__,
 					error->message, mcc, mnc, spn, imsi);
 			g_error_free(error);
+			error = NULL;
 		}
 	}
 
@@ -152,6 +153,7 @@ static int provision_get_settings(const char *mcc, const char *mnc,
 						" mnc %s spn: %s", __func__,
 						error->message, mcc, mnc, spn);
 				g_error_free(error);
+				error = NULL;
 			}
 		}
 	}


### PR DESCRIPTION
Fix a crash in provision_get_settings() caused by the code
freeing 'error' with g_error_free() but not setting the value
to NULL afterwards.  This can cause a subsequent call to
g_error_free() to happen again with an invalid pointer value.
