### PR TITLE
Use EF_OPL to check roaming status

### DIFF
--- a/src/simutil.c
+++ b/src/simutil.c
@@ -1103,6 +1103,9 @@ static const struct sim_eons_operator_info *
 	const struct opl_operator *opl;
 	int i;
 
+	if (eons == NULL)
+		return NULL;
+
 	for (l = eons->opl_list; l; l = l->next) {
 		opl = l->data;
 


### PR DESCRIPTION
Some operators (MVNOs, or Orange/T_Mobile UK case) store in EF_OPL their home networks, so we remove the roaming flag if the network we are registered in is present in the file. Although this is not strictly conformant with the standard, seems to be common practice among operators, as no operator would care about changing the displayed name for a network which is not among its home networks (EF_OPL stores the index for the EF_PNN entry for a PLMN).
