### PR TITLE
src: Re-order emission of signals in network atom

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1384,14 +1384,14 @@ void ofono_netreg_status_notify(struct ofono_netreg *netreg, int status,
 					GINT_TO_POINTER(netreg->status));
 	}
 
+	if (netreg->technology != tech)
+		set_registration_technology(netreg, tech);
+
 	if (netreg->location != lac)
 		set_registration_location(netreg, lac);
 
 	if (netreg->cellid != ci)
 		set_registration_cellid(netreg, ci);
-
-	if (netreg->technology != tech)
-		set_registration_technology(netreg, tech);
 
 	if (netreg->status == NETWORK_REGISTRATION_STATUS_REGISTERED ||
 		netreg->status == NETWORK_REGISTRATION_STATUS_ROAMING) {


### PR DESCRIPTION
Location service expects technology to change before cellid, this PR reorders the emission of signals to achieve this.

To test: execute "monitor-ofono" in one shell. In another one:

# set-tech-preference gsm

We should see a sequence of events in the output of monitor ofono as follows:

{NetworkRegistration} [/ril_0] Technology = [gsm|edge]
{NetworkRegistration} [/ril_0] LocationAreaCode = xxx
{NetworkRegistration} [/ril_0] CellId = xxx

# set-tech-preference umts

We should see a sequence of events in the output of monitor ofono as follows:

{NetworkRegistration} [/ril_0] Technology = [umts|hspa]
{NetworkRegistration} [/ril_0] CellId = xxx
