### PR TITLE
test/rilmodem: Fix serial number check

### DIFF
--- a/test/rilmodem/test-sim-online
+++ b/test/rilmodem/test-sim-online
@@ -193,7 +193,8 @@ def main(args):
 	assert properties["Model"] == "Fake Modem Model"
 	assert properties["Type"] == "hardware"
 
-	assert properties["Serial"] == "000000000000000"
+	if args.emulator:
+		assert properties["Serial"] == "000000000000000"
 
 	assert properties["Manufacturer"] == "Fake Manufacturer"
 


### PR DESCRIPTION
Only compare to the emulator's hard-coded serial number when
the '--emulator' argument is given, not when testing in real
hardware.

Fixes https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1334867 , a regression caused by commit 2a3958695cdc77252e542015954bc192c8f8d04f .
