### PR TITLE
Make CLIR codes coherent with properties

### DIFF
--- a/src/call-settings.c
+++ b/src/call-settings.c
@@ -840,7 +840,7 @@ static gboolean clir_ss_control(int type,
 	case SS_CONTROL_TYPE_REGISTRATION:
 	case SS_CONTROL_TYPE_ACTIVATION:
 		cs->ss_req_type = SS_CONTROL_TYPE_ACTIVATION;
-		cs->driver->clir_set(cs, OFONO_CLIR_OPTION_SUPPRESSION,
+		cs->driver->clir_set(cs, CLIR_STATUS_PROVISIONED_PERMANENT,
 					clir_ss_set_callback, cs);
 		break;
 
@@ -852,7 +852,7 @@ static gboolean clir_ss_control(int type,
 	case SS_CONTROL_TYPE_DEACTIVATION:
 	case SS_CONTROL_TYPE_ERASURE:
 		cs->ss_req_type = SS_CONTROL_TYPE_DEACTIVATION;
-		cs->driver->clir_set(cs, OFONO_CLIR_OPTION_INVOCATION,
+		cs->driver->clir_set(cs, CLIR_STATUS_NOT_PROVISIONED,
 					clir_ss_set_callback, cs);
 		break;
 	};


### PR DESCRIPTION
When using dialer to enter CLIR SS codes, the operations in the network were different than those sent when using the call setting interface properties. Works for mako and Krillin.

*31# -> Activates CLIR: no number is shown in called phones
#31# -> Deactivates CLIR: number is shown again in called phones. Calls to #31#<number> should still hide the call in destination.

This is related to https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1263229
