### PR TITLE
plugins: don't require MMS proxy

### DIFF
--- a/plugins/ubuntu-apndb.c
+++ b/plugins/ubuntu-apndb.c
@@ -400,7 +400,7 @@ static void toplevel_apndb_start(GMarkupParseContext *context,
 	type = determine_apn_type(types);
 
 	if (type == OFONO_GPRS_CONTEXT_TYPE_ANY ||
-		(type == OFONO_GPRS_CONTEXT_TYPE_MMS && mmsproxy == NULL)) {
+		(type == OFONO_GPRS_CONTEXT_TYPE_MMS && mmscenter == NULL)) {
 		DBG("Skipping %s context; types: %s", apn, types);
 		return;
 	}


### PR DESCRIPTION
The current Ubuntu provisioning logic skips MMS
APNs that don't define an MMS proxy.  In fact,
the only required MMS attribute is the message
center.

This fixes the ofono task of the following bug:

https://bugs.launchpad.net/ubuntu-rtm/+source/ubuntu-download-manager/+bug/1362008
