### PR TITLE
rilmodem: Fix crash when switching on/off FM

### DIFF
--- a/drivers/rilmodem/gprs.h
+++ b/drivers/rilmodem/gprs.h
@@ -28,6 +28,7 @@ struct ril_gprs_data {
 	int tech;
 	int state_changed_unsol;
 	int pending_deact_req;
+	guint status_retry_cb_id;
 };
 
 int ril_gprs_probe(struct ofono_gprs *gprs, unsigned int vendor, void *data);


### PR DESCRIPTION
Due to a race condition, we can crash if we go too fast from FM on to FM off and then back fast to on. This is due to a pending callback that was not removed from the main loop on the removal of the gprs atom.
