### PR TITLE
Sync radiosettings

### DIFF
--- a/doc/radio-settings-api.txt
+++ b/doc/radio-settings-api.txt
@@ -54,7 +54,7 @@ Properties	string TechnologyPreference [readwrite]
 			at a given moment we could be registered in a gsm or
 			umts network, but never in an lte one.
 
-		array{string} ModemTechnologies [readonly, optional]
+		array{string} AvailableTechnologies [readonly, optional]
 
 			List of values for TechnologyPreference property
 			supported by the modem.

--- a/drivers/mtkmodem/radio-settings.c
+++ b/drivers/mtkmodem/radio-settings.c
@@ -125,54 +125,53 @@ static int mtk_radio_settings_probe(struct ofono_radio_settings *rs,
 	return 0;
 }
 
-static void mtk_query_modem_rats_cb(struct ril_msg *message, gpointer user_data)
+static void mtk_query_available_rats_cb(struct ril_msg *message,
+					gpointer user_data)
 {
 	struct cb_data *cbd = user_data;
 	struct ofono_radio_settings *rs = cbd->user;
 	struct radio_data *rd = ofono_radio_settings_get_data(rs);
-	ofono_radio_settings_modem_rats_query_cb_t cb = cbd->cb;
-	ofono_bool_t modem_rats[OFONO_RADIO_ACCESS_MODE_LAST] = { FALSE };
+	ofono_radio_settings_available_rats_query_cb_t cb = cbd->cb;
+	unsigned int available_rats = OFONO_RADIO_ACCESS_MODE_GSM;
 	int slot_3g, is_3g;
 
 	if (message->error != RIL_E_SUCCESS) {
 		ofono_error("%s: error %s", __func__,
 				ril_error_to_string(message->error));
-		CALLBACK_WITH_FAILURE(cb, NULL, cbd->data);
+		CALLBACK_WITH_FAILURE(cb, 0, cbd->data);
 		return;
 	}
 
 	slot_3g = g_mtk_reply_parse_get_3g_capability(rd->ril, message);
 	if (slot_3g < 0) {
 		ofono_error("%s: parse error", __func__);
-		CALLBACK_WITH_FAILURE(cb, NULL, cbd->data);
+		CALLBACK_WITH_FAILURE(cb, 0, cbd->data);
 		return;
 	}
 
 	is_3g = (g_ril_get_slot(rd->ril) == slot_3g);
 
-	modem_rats[OFONO_RADIO_ACCESS_MODE_GSM] = TRUE;
-
 	if (is_3g) {
-		modem_rats[OFONO_RADIO_ACCESS_MODE_UMTS] = TRUE;
+		available_rats |= OFONO_RADIO_ACCESS_MODE_UMTS;
 
 		if (getenv("OFONO_RIL_RAT_LTE"))
-			modem_rats[OFONO_RADIO_ACCESS_MODE_LTE] = TRUE;
+			available_rats |= OFONO_RADIO_ACCESS_MODE_LTE;
 	}
 
-	CALLBACK_WITH_SUCCESS(cb, modem_rats, cbd->data);
+	CALLBACK_WITH_SUCCESS(cb, available_rats, cbd->data);
 }
 
-static void mtk_query_modem_rats(struct ofono_radio_settings *rs,
-				ofono_radio_settings_modem_rats_query_cb_t cb,
-				void *data)
+static void mtk_query_available_rats(struct ofono_radio_settings *rs,
+			ofono_radio_settings_available_rats_query_cb_t cb,
+			void *data)
 {
 	struct radio_data *rd = ofono_radio_settings_get_data(rs);
 	struct cb_data *cbd = cb_data_new(cb, data, rs);
 
 	if (g_ril_send(rd->ril, MTK_RIL_REQUEST_GET_3G_CAPABILITY, NULL,
-			mtk_query_modem_rats_cb, cbd, g_free) <= 0) {
+			mtk_query_available_rats_cb, cbd, g_free) <= 0) {
 		g_free(cbd);
-		CALLBACK_WITH_FAILURE(cb, NULL, data);
+		CALLBACK_WITH_FAILURE(cb, 0, data);
 	}
 }
 
@@ -184,7 +183,7 @@ static struct ofono_radio_settings_driver driver = {
 	.set_rat_mode		= ril_set_rat_mode,
 	.query_fast_dormancy	= ril_query_fast_dormancy,
 	.set_fast_dormancy	= mtk_set_fast_dormancy,
-	.query_modem_rats	= mtk_query_modem_rats
+	.query_available_rats	= mtk_query_available_rats
 };
 
 void mtk_radio_settings_init(void)

--- a/drivers/rilmodem/radio-settings.c
+++ b/drivers/rilmodem/radio-settings.c
@@ -208,32 +208,32 @@ void ril_set_fast_dormancy(struct ofono_radio_settings *rs,
 	}
 }
 
-static ofono_bool_t query_modem_rats_cb(gpointer user_data)
+static ofono_bool_t query_available_rats_cb(gpointer user_data)
 {
-	ofono_bool_t modem_rats[OFONO_RADIO_ACCESS_MODE_LAST] = { FALSE };
+	unsigned int available_rats;
 	struct cb_data *cbd = user_data;
-	ofono_radio_settings_modem_rats_query_cb_t cb = cbd->cb;
+	ofono_radio_settings_available_rats_query_cb_t cb = cbd->cb;
 
-	modem_rats[OFONO_RADIO_ACCESS_MODE_GSM] = TRUE;
-	modem_rats[OFONO_RADIO_ACCESS_MODE_UMTS] = TRUE;
+	available_rats = OFONO_RADIO_ACCESS_MODE_GSM
+				| OFONO_RADIO_ACCESS_MODE_UMTS;
 
 	if (getenv("OFONO_RIL_RAT_LTE"))
-		modem_rats[OFONO_RADIO_ACCESS_MODE_LTE] = TRUE;
+		available_rats |= OFONO_RADIO_ACCESS_MODE_LTE;
 
-	CALLBACK_WITH_SUCCESS(cb, modem_rats, cbd->data);
+	CALLBACK_WITH_SUCCESS(cb, available_rats, cbd->data);
 
 	g_free(cbd);
 
 	return FALSE;
 }
 
-static void ril_query_modem_rats(struct ofono_radio_settings *rs,
-				ofono_radio_settings_modem_rats_query_cb_t cb,
-				void *data)
+static void ril_query_available_rats(struct ofono_radio_settings *rs,
+			ofono_radio_settings_available_rats_query_cb_t cb,
+			void *data)
 {
 	struct cb_data *cbd = cb_data_new(cb, data, rs);
 
-	g_idle_add(query_modem_rats_cb, cbd);
+	g_idle_add(query_available_rats_cb, cbd);
 }
 
 void ril_delayed_register(const struct ofono_error *error, void *user_data)
@@ -283,7 +283,7 @@ static struct ofono_radio_settings_driver driver = {
 	.set_rat_mode		= ril_set_rat_mode,
 	.query_fast_dormancy	= ril_query_fast_dormancy,
 	.set_fast_dormancy	= ril_set_fast_dormancy,
-	.query_modem_rats	= ril_query_modem_rats
+	.query_available_rats	= ril_query_available_rats
 };
 
 void ril_radio_settings_init(void)

--- a/include/radio-settings.h
+++ b/include/radio-settings.h
@@ -29,14 +29,11 @@ extern "C" {
 #include <ofono/types.h>
 
 enum ofono_radio_access_mode {
-	OFONO_RADIO_ACCESS_MODE_ANY	= 0,
-	OFONO_RADIO_ACCESS_MODE_GSM	= 1,
-	OFONO_RADIO_ACCESS_MODE_UMTS	= 2,
-	OFONO_RADIO_ACCESS_MODE_LTE	= 3,
+	OFONO_RADIO_ACCESS_MODE_ANY	= 0x0,
+	OFONO_RADIO_ACCESS_MODE_GSM	= 0x1,
+	OFONO_RADIO_ACCESS_MODE_UMTS	= 0x2,
+	OFONO_RADIO_ACCESS_MODE_LTE	= 0x4,
 };
-
-/* Set this to latest in ofono_radio_access_mode + 1 */
-#define OFONO_RADIO_ACCESS_MODE_LAST (OFONO_RADIO_ACCESS_MODE_LTE + 1)
 
 enum ofono_radio_band_gsm {
 	OFONO_RADIO_BAND_GSM_ANY,
@@ -83,9 +80,9 @@ typedef void (*ofono_radio_settings_fast_dormancy_query_cb_t)(
 						ofono_bool_t enable,
 						void *data);
 
-typedef void (*ofono_radio_settings_modem_rats_query_cb_t)(
+typedef void (*ofono_radio_settings_available_rats_query_cb_t)(
 						const struct ofono_error *error,
-						const ofono_bool_t rats[],
+						unsigned int available_rats,
 						void *data);
 
 struct ofono_radio_settings_driver {
@@ -115,9 +112,9 @@ struct ofono_radio_settings_driver {
 				ofono_bool_t enable,
 				ofono_radio_settings_fast_dormancy_set_cb_t,
 				void *data);
-	void (*query_modem_rats)(struct ofono_radio_settings *rs,
-				ofono_radio_settings_modem_rats_query_cb_t cb,
-				void *data);
+	void (*query_available_rats)(struct ofono_radio_settings *rs,
+			ofono_radio_settings_available_rats_query_cb_t cb,
+			void *data);
 };
 
 int ofono_radio_settings_driver_register(

--- a/test/list-modems
+++ b/test/list-modems
@@ -45,7 +45,7 @@ for path, properties in modems:
 					"PrimaryContexts",
 					"LockedPins",
 					"Features",
-					"ModemTechnologies"]:
+					"AvailableTechnologies"]:
 				val = ""
 				for i in properties[key]:
 					val += i + " "


### PR DESCRIPTION
Sync with upstream RadioSettings changes, renaming the ModemTechnologies property to AvailableTechnologies. Note that whenever this gets merged system-settings has to be changed too to use the new name.