### PR TITLE
rilmodem: set android property if available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,6 +165,9 @@ builtin_sources += drivers/rilmodem/rilmodem.h \
 			drivers/rilmodem/radio-settings.c \
 			drivers/rilmodem/call-barring.c \
 			drivers/rilmodem/phonebook.c
+
+builtin_cflags += @ANDROID_PROP_CFLAGS@
+builtin_libadd += @ANDROID_PROP_LIBS@
 endif
 
 if ISIMODEM

--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,14 @@ AC_ARG_ENABLE(rilmodem, AC_HELP_STRING([--disable-rilmodem],
                                 [disable RIL modem support]),
                                         [enable_rilmodem=${enableval}])
 AM_CONDITIONAL(RILMODEM, test "${enable_rilmodem}" != "no")
+if test "${enable_rilmodem}" != "no"; then
+	PKG_CHECK_MODULES(ANDROID_PROP, libandroid-properties,
+		[AC_DEFINE([WITH_HYBRIS_ANDROID_PROPERTIES], [1],
+			[Define to 1 if we have android property calls from libhybris.])],
+		[dummy=yes])
+	AC_SUBST(ANDROID_PROP_CFLAGS)
+	AC_SUBST(ANDROID_PROP_LIBS)
+fi
 
 AC_ARG_ENABLE(qmimodem, AC_HELP_STRING([--disable-qmimodem],
 				[disable Qualcomm QMI modem support]),

--- a/drivers/rilmodem/android_properties.h
+++ b/drivers/rilmodem/android_properties.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2014  Canonical Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#if defined(WITH_HYBRIS_ANDROID_PROPERTIES)
+
+#include <hybris/properties/properties.h>
+
+#define HAVE_ANDROID_PROP 1
+
+#else /* !WITH_HYBRIS_ANDROID_PROPERTIES */
+
+#define PROP_NAME_MAX 32
+#define PROP_VALUE_MAX 92
+
+#define property_set(key, value) -1
+#define property_get(key, value, default_value) -1
+#define property_list(propfn, cookie) -1
+
+#if defined(HAVE_ANDROID_PROP)
+#undef HAVE_ANDROID_PROP
+#endif
+
+#endif /* !WITH_HYBRIS_ANDROID_PROPERTIES */

--- a/drivers/rilmodem/devinfo.c
+++ b/drivers/rilmodem/devinfo.c
@@ -40,6 +40,7 @@
 
 #include "rilmodem.h"
 #include "grilreply.h"
+#include "android_properties.h"
 
 /*
  * TODO: The functions in this file are stubbed out, and
@@ -94,6 +95,9 @@ static void query_revision_cb(struct ril_msg *message, gpointer user_data)
 	}
 
 	revision = g_ril_reply_parse_baseband_version(ril, message);
+#if defined(HAVE_ANDROID_PROP)
+	property_set("gsm.version.baseband", revision);
+#endif
 
 	cb(&error, revision, cbd->data);
 

--- a/drivers/rilmodem/gprs.c
+++ b/drivers/rilmodem/gprs.c
@@ -43,6 +43,7 @@
 #include "grilutil.h"
 #include "common.h"
 #include "rilmodem.h"
+#include "android_properties.h"
 
 #include "grilreply.h"
 #include "grilrequest.h"
@@ -291,6 +292,11 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 
 	if (gd->tech != reply->reg_state.tech) {
 		gd->tech = reply->reg_state.tech;
+
+#if defined(HAVE_ANDROID_PROP)
+		property_set("gsm.network.type",
+				ril_radio_tech_to_string(reply->reg_state.tech));
+#endif
 
 		ofono_gprs_bearer_notify(gprs,
 				ril_tech_to_bearer_tech(reply->reg_state.tech));

--- a/drivers/rilmodem/sim.c
+++ b/drivers/rilmodem/sim.c
@@ -548,6 +548,20 @@ static void ril_imsi_cb(struct ril_msg *message, gpointer user_data)
 		goto error;
 	}
 
+#if defined(HAVE_ANDROID_PROP)
+	{
+		gchar buf[OFONO_MAX_MCC_LENGTH + OFONO_MAX_MNC_LENGTH + 1];
+		int mnc_len;
+
+		mnc_len = __ofono_sim_mnclength_get_mnclength(imsi);
+		if (mnc_len > 0 && mnc_len <= OFONO_MAX_MNC_LENGTH) {
+			strncpy(buf, imsi, OFONO_MAX_MCC_LENGTH + mnc_len);
+			buf[OFONO_MAX_MCC_LENGTH + mnc_len] = '\0';
+			property_set("gsm.sim.operator.numeric", buf);
+		}
+	}
+#endif
+
 	cb(&error, imsi, cbd->data);
 	g_free(imsi);
 

--- a/drivers/rilmodem/sim.c
+++ b/drivers/rilmodem/sim.c
@@ -559,6 +559,9 @@ static void ril_imsi_cb(struct ril_msg *message, gpointer user_data)
 			buf[OFONO_MAX_MCC_LENGTH + mnc_len] = '\0';
 			property_set("gsm.sim.operator.numeric", buf);
 		}
+
+		property_set("gsm.sim.operator.iso-country",
+			__ofono_sim_mnclength_get_country_code(imsi));
 	}
 #endif
 

--- a/gril/grilutil.c
+++ b/gril/grilutil.c
@@ -215,23 +215,23 @@ const char *ril_radio_tech_to_string(int radio_tech)
 {
 	switch (radio_tech) {
 	case RADIO_TECH_UNKNOWN:
-		return "UNKNOWN";
+		return "Unknown";
 	case RADIO_TECH_GPRS:
 		return "GPRS";
 	case RADIO_TECH_EDGE:
-		return	"EDGE";
+		return "EDGE";
 	case RADIO_TECH_UMTS:
 		return "UMTS";
 	case RADIO_TECH_IS95A:
-		return "IS95A";
+		return "CDMA-IS95A";
 	case RADIO_TECH_IS95B:
-		return "IS95B";
+		return "CDMA-IS95B";
 	case RADIO_TECH_1xRTT:
 		return "1xRTT";
 	case RADIO_TECH_EVDO_0:
-		return "EVDO_0";
+		return "EvDo-rev.0";
 	case RADIO_TECH_EVDO_A:
-		return "EVDO_A";
+		return "EvDo-rev.A";
 	case RADIO_TECH_HSDPA:
 		return "HSDPA";
 	case RADIO_TECH_HSUPA:
@@ -239,9 +239,9 @@ const char *ril_radio_tech_to_string(int radio_tech)
 	case RADIO_TECH_HSPA:
 		return "HSPA";
 	case RADIO_TECH_EVDO_B:
-		return "EVDO_B";
+		return "EvDo-rev.B";
 	case RADIO_TECH_EHRPD:
-		return "EHRPD";
+		return "eHRPD";
 	case RADIO_TECH_LTE:
 		return "LTE";
 	case RADIO_TECH_HSPAP:

--- a/include/netreg.h
+++ b/include/netreg.h
@@ -114,6 +114,7 @@ int ofono_netreg_get_status(struct ofono_netreg *netreg);
 int ofono_netreg_get_technology(struct ofono_netreg *netreg);
 const char *ofono_netreg_get_mcc(struct ofono_netreg *netreg);
 const char *ofono_netreg_get_mnc(struct ofono_netreg *netreg);
+const char *ofono_netreg_get_name(struct ofono_netreg *netreg);
 
 #ifdef __cplusplus
 }

--- a/include/sim-mnclength.h
+++ b/include/sim-mnclength.h
@@ -31,6 +31,7 @@ extern "C" {
 struct ofono_sim_mnclength_driver {
 	const char *name;
 	int (*get_mnclength)(const char *imsi);
+	const char *(*get_country_code)(const char *mcc);
 };
 
 int ofono_sim_mnclength_driver_register(

--- a/plugins/mnclength.c
+++ b/plugins/mnclength.c
@@ -38,6 +38,7 @@
 struct mcc_mnclength {
 	int mcc;
 	int mnclength;
+	const char *country_code;
 };
 
 /*
@@ -50,242 +51,242 @@ struct mcc_mnclength {
  * given a default length depending on their geographical area.
  */
 static struct mcc_mnclength mnclen_db[] = {
-	{202, 2},	/* Greece */
-	{204, 2},	/* Netherlands (Kingdom of the) */
-	{206, 2},	/* Belgium */
-	{208, 2},	/* France */
-	{212, 2},	/* Monaco (Principality of) */
-	{213, 2},	/* Andorra (Principality of) */
-	{214, 2},	/* Spain */
-	{216, 2},	/* Hungary */
-	{218, 2},	/* Bosnia and Herzegovina */
-	{219, 2},	/* Croatia (Republic of) */
-	{220, 2},	/* Serbia (Republic of) */
-	{222, 2},	/* Italy */
-	{225, 2},	/* Vatican City State */
-	{226, 2},	/* Romania */
-	{228, 2},	/* Switzerland (Confederation of) */
-	{230, 2},	/* Czech Republic */
-	{231, 2},	/* Slovak Republic */
-	{232, 2},	/* Austria */
-	{234, 2},	/* United Kingdom of G. Britain and Northern Ireland */
-	{235, 2},	/* United Kingdom of G. Britain and Northern Ireland */
-	{238, 2},	/* Denmark */
-	{240, 2},	/* Sweden */
-	{242, 2},	/* Norway */
-	{244, 2},	/* Finland */
-	{246, 2},	/* Lithuania (Republic of) */
-	{247, 2},	/* Latvia (Republic of) */
-	{248, 2},	/* Estonia (Republic of) */
-	{250, 2},	/* Russian Federation */
-	{255, 2},	/* Ukraine */
-	{257, 2},	/* Belarus (Republic of) */
-	{259, 2},	/* Moldova (Republic of) */
-	{260, 2},	/* Poland (Republic of) */
-	{262, 2},	/* Germany (Federal Republic of) */
-	{266, 2},	/* Gibraltar */
-	{268, 2},	/* Portugal */
-	{270, 2},	/* Luxembourg */
-	{272, 2},	/* Ireland */
-	{274, 2},	/* Iceland */
-	{276, 2},	/* Albania (Republic of) */
-	{278, 2},	/* Malta */
-	{280, 2},	/* Cyprus (Republic of) */
-	{282, 2},	/* Georgia */
-	{283, 2},	/* Armenia (Republic of) */
-	{284, 2},	/* Bulgaria (Republic of) */
-	{286, 2},	/* Turkey */
-	{288, 2},	/* Faroe Islands */
-	{290, 2},	/* Greenland (Denmark) */
-	{292, 2},	/* San Marino (Republic of) */
-	{293, 2},	/* Slovenia (Republic of) */
-	{294, 2},	/* The Former Yugoslav Republic of Macedonia */
-	{295, 2},	/* Liechtenstein (Principality of) */
-	{297, 2},	/* Montenegro (Republic of) */
-	{302, 3},	/* Canada */
-	{308, 2},	/* Saint Pierre and Miquelon (french Republic) */
-	{310, 3},	/* United States of America */
-	{311, 3},	/* United States of America */
-	{312, 3},	/* United States of America */
-	{313, 3},	/* United States of America */
-	{314, 3},	/* United States of America */
-	{315, 3},	/* United States of America */
-	{316, 3},	/* United States of America */
-	{330, 3},	/* Puerto Rico */
-	{332, 3},	/* United States Virgin Islands */
-	{334, 3},	/* Mexico */
-	{338, 3},	/* Jamaica */
-	{340, 2},	/* Guadeloupe and Martinique (French Departments) */
-	{342, 3},	/* Barbados */
-	{344, 3},	/* Antigua and Barbuda */
-	{346, 3},	/* Cayman Islands */
-	{348, 3},	/* British Virgin Islands */
-	{350, 3},	/* Bermuda */
-	{352, 3},	/* Grenada */
-	{354, 3},	/* Montserrat */
-	{356, 3},	/* Saint Kitts and Nevis */
-	{358, 3},	/* Saint Lucia */
-	{360, 3},	/* Saint Vincent and the Grenadines */
-	{362, 2},	/* Curazao, St Maarten, Bonaire, St Eustatius, Saba */
-	{363, 2},	/* Aruba */
-	{364, 3},	/* Bahamas (Commonwealth of the) */
-	{365, 3},	/* Anguilla */
-	{366, 3},	/* Dominica (Commonwealth of) */
-	{368, 2},	/* Cuba */
-	{370, 2},	/* Dominican Republic */
-	{372, 2},	/* Haiti (Republic of) */
-	{374, 2},	/* Trinidad and Tobago */
-	{376, 3},	/* Turks and Caicos Islands */
-	{400, 2},	/* Azerbaijani Republic */
-	{401, 2},	/* Kazakhstan (Republic of) */
-	{402, 2},	/* Bhutan (Kingdom of) */
-	{404, 2},	/* India (Republic of) */
-	{405, 2},	/* India (Republic of) */
-	{406, 2},	/* India (Republic of) */
-	{410, 2},	/* Pakistan (Islamic Republic of) */
-	{412, 2},	/* Afghanistan */
-	{413, 2},	/* Sri Lanka (Democratic Socialist Republic of) */
-	{414, 2},	/* Myanmar (the Republic of the Union of) */
-	{415, 2},	/* Lebanon */
-	{416, 2},	/* Jordan (Hashemite Kingdom of) */
-	{417, 2},	/* Syrian Arab Republic */
-	{418, 2},	/* Iraq (Republic of) */
-	{419, 2},	/* Kuwait (State of) */
-	{420, 2},	/* Saudi Arabia (Kingdom of) */
-	{421, 2},	/* Yemen (Republic of) */
-	{422, 2},	/* Oman (Sultanate of) */
-	{424, 2},	/* United Arab Emirates */
-	{425, 2},	/* Israel (State of) */
-	{426, 2},	/* Bahrain (Kingdom of) */
-	{427, 2},	/* Qatar (State of) */
-	{428, 2},	/* Mongolia */
-	{429, 2},	/* Nepal (Federal Democratic Republic of) */
-	{430, 2},	/* United Arab Emirates */
-	{431, 2},	/* United Arab Emirates */
-	{432, 2},	/* Iran (Islamic Republic of) */
-	{434, 2},	/* Uzbekistan (Republic of) */
-	{436, 2},	/* Tajikistan (Republic of) */
-	{437, 2},	/* Kyrgyz Republic */
-	{438, 2},	/* Turkmenistan */
-	{440, 2},	/* Japan */
-	{441, 2},	/* Japan */
-	{450, 2},	/* Korea (Republic of) */
-	{452, 2},	/* Viet Nam (Socialist Republic of) */
-	{454, 2},	/* Hong Kong, China */
-	{455, 2},	/* Macao, China */
-	{456, 2},	/* Cambodia (Kingdom of) */
-	{457, 2},	/* Lao People's Democratic Republic */
-	{460, 2},	/* China (People's Republic of) */
-	{461, 2},	/* China (People's Republic of) */
-	{466, 2},	/* Taiwan, China */
-	{467, 2},	/* Democratic People's Republic of Korea */
-	{470, 2},	/* Bangladesh (People's Republic of) */
-	{472, 2},	/* Maldives (Republic of) */
-	{502, 2},	/* Malaysia */
-	{505, 2},	/* Australia */
-	{510, 2},	/* Indonesia (Republic of) */
-	{514, 2},	/* Democratic Republic of Timor-Leste */
-	{515, 2},	/* Philippines (Republic of the) */
-	{520, 2},	/* Thailand */
-	{525, 2},	/* Singapore (Republic of) */
-	{528, 2},	/* Brunei Darussalam */
-	{530, 2},	/* New Zealand */
-	{536, 2},	/* Nauru (Republic of) */
-	{537, 2},	/* Papua New Guinea */
-	{539, 2},	/* Tonga (Kingdom of) */
-	{540, 2},	/* Solomon Islands */
-	{541, 2},	/* Vanuatu (Republic of) */
-	{542, 2},	/* Fiji (Republic of) */
-	{543, 2},	/* Wallis and Futuna (french territory) */
-	{544, 2},	/* American Samoa */
-	{545, 2},	/* Kiribati (Republic of) */
-	{546, 2},	/* New Caledonia (french territory) */
-	{547, 2},	/* French Polynesia (french territory) */
-	{548, 2},	/* Cook Islands */
-	{549, 2},	/* Samoa (Independent State of) */
-	{550, 2},	/* Micronesia (Federated States of) */
-	{551, 2},	/* Marshall Islands (Republic of the) */
-	{552, 2},	/* Palau (Republic of) */
-	{553, 2},	/* Tuvalu */
-	{555, 2},	/* Niue */
-	{602, 2},	/* Egypt (Arab Republic of) */
-	{603, 2},	/* Algeria (People's Democratic Republic of) */
-	{604, 2},	/* Morocco (Kingdom of) */
-	{605, 2},	/* Tunisia */
-	{606, 2},	/* Libya */
-	{607, 2},	/* Gambia (Republic of the) */
-	{608, 2},	/* Senegal (Republic of) */
-	{609, 2},	/* Mauritania (Islamic Republic of) */
-	{610, 2},	/* Mali (Republic of) */
-	{611, 2},	/* Guinea (Republic of) */
-	{612, 2},	/* Ivory Coast (Republic of) */
-	{613, 2},	/* Burkina Faso */
-	{614, 2},	/* Niger (Republic of the) */
-	{615, 2},	/* Togolese Republic */
-	{616, 2},	/* Benin (Republic of) */
-	{617, 2},	/* Mauritius (Republic of) */
-	{618, 2},	/* Liberia (Republic of) */
-	{619, 2},	/* Sierra Leone */
-	{620, 2},	/* Ghana */
-	{621, 2},	/* Nigeria (Federal Republic of) */
-	{622, 2},	/* Chad (Republic of) */
-	{623, 2},	/* Central African Republic */
-	{624, 2},	/* Cameroon (Republic of) */
-	{625, 2},	/* Cape Verde (Republic of) */
-	{626, 2},	/* Sao Tome and Principe (Democratic Republic of) */
-	{627, 2},	/* Equatorial Guinea (Republic of) */
-	{628, 2},	/* Gabonese Republic */
-	{629, 2},	/* Congo (Republic of the) */
-	{630, 2},	/* Democratic Republic of the Congo */
-	{631, 2},	/* Angola (Republic of) */
-	{632, 2},	/* Guinea-Bissau (Republic of) */
-	{633, 2},	/* Seychelles (Republic of) */
-	{634, 2},	/* Sudan (Republic of the) */
-	{635, 2},	/* Rwanda (Republic of) */
-	{636, 2},	/* Ethiopia (Federal Democratic Republic of) */
-	{637, 2},	/* Somali Democratic Republic */
-	{638, 2},	/* Djibouti (Republic of) */
-	{639, 2},	/* Kenya (Republic of) */
-	{640, 2},	/* Tanzania (United Republic of) */
-	{641, 2},	/* Uganda (Republic of) */
-	{642, 2},	/* Burundi (Republic of) */
-	{643, 2},	/* Mozambique (Republic of) */
-	{645, 2},	/* Zambia (Republic of) */
-	{646, 2},	/* Madagascar (Republic of) */
-	{647, 2},	/* French Departments in the Indian Ocean */
-	{648, 2},	/* Zimbabwe (Republic of) */
-	{649, 2},	/* Namibia (Republic of) */
-	{650, 2},	/* Malawi */
-	{651, 2},	/* Lesotho (Kingdom of) */
-	{652, 2},	/* Botswana (Republic of) */
-	{653, 2},	/* Swaziland (Kingdom of) */
-	{654, 2},	/* Comoros (Union of the) */
-	{655, 2},	/* South Africa (Republic of) */
-	{657, 2},	/* Eritrea */
-	{658, 2},	/* Saint Helena, Ascension and Tristan da Cunha */
-	{659, 2},	/* South Sudan (Republic of) */
-	{702, 2},	/* Belize */
-	{704, 2},	/* Guatemala (Republic of) */
-	{706, 2},	/* El Salvador (Republic of) */
-	{708, 3},	/* Honduras (Republic of) */
-	{710, 2},	/* Nicaragua */
-	{712, 2},	/* Costa Rica */
-	{714, 2},	/* Panama (Republic of) */
-	{716, 2},	/* Peru */
-	{722, 3},	/* Argentine Republic */
-	{724, 2},	/* Brazil (Federative Republic of) */
-	{730, 2},	/* Chile */
-	{732, 3},	/* Colombia (Republic of) */
-	{734, 2},	/* Venezuela (Bolivarian Republic of) */
-	{736, 2},	/* Bolivia (Plurinational State of) */
-	{738, 2},	/* Guyana */
-	{740, 2},	/* Ecuador */
-	{742, 2},	/* French Guiana (French Department of) */
-	{744, 2},	/* Paraguay (Republic of) */
-	{746, 2},	/* Suriname (Republic of) */
-	{748, 2},	/* Uruguay (Eastern Republic of) */
-	{750, 3},	/* Falkland Islands (Malvinas) */
-	{901, 2},	/* International Mobile, shared code */
+	{202, 2, "gr"},	/* Greece */
+	{204, 2, "nl"},	/* Netherlands (Kingdom of the) */
+	{206, 2, "be"},	/* Belgium */
+	{208, 2, "fr"},	/* France */
+	{212, 2, "mc"},	/* Monaco (Principality of) */
+	{213, 2, "ad"},	/* Andorra (Principality of) */
+	{214, 2, "es"},	/* Spain */
+	{216, 2, "hu"},	/* Hungary */
+	{218, 2, "ba"},	/* Bosnia and Herzegovina */
+	{219, 2, "hr"},	/* Croatia (Republic of) */
+	{220, 2, "rs"},	/* Serbia (Republic of) */
+	{222, 2, "it"},	/* Italy */
+	{225, 2, "va"},	/* Vatican City State */
+	{226, 2, "ro"},	/* Romania */
+	{228, 2, "ch"},	/* Switzerland (Confederation of) */
+	{230, 2, "cz"},	/* Czech Republic */
+	{231, 2, "sk"},	/* Slovak Republic */
+	{232, 2, "at"},	/* Austria */
+	{234, 2, "gb"},	/* United Kingdom of G. Britain and Northern Ireland */
+	{235, 2, "gb"},	/* United Kingdom of G. Britain and Northern Ireland */
+	{238, 2, "dk"},	/* Denmark */
+	{240, 2, "se"},	/* Sweden */
+	{242, 2, "no"},	/* Norway */
+	{244, 2, "fi"},	/* Finland */
+	{246, 2, "lt"},	/* Lithuania (Republic of) */
+	{247, 2, "lv"},	/* Latvia (Republic of) */
+	{248, 2, "ee"},	/* Estonia (Republic of) */
+	{250, 2, "ru"},	/* Russian Federation */
+	{255, 2, "ua"},	/* Ukraine */
+	{257, 2, "by"},	/* Belarus (Republic of) */
+	{259, 2, "md"},	/* Moldova (Republic of) */
+	{260, 2, "pl"},	/* Poland (Republic of) */
+	{262, 2, "de"},	/* Germany (Federal Republic of) */
+	{266, 2, "gi"},	/* Gibraltar */
+	{268, 2, "pt"},	/* Portugal */
+	{270, 2, "lu"},	/* Luxembourg */
+	{272, 2, "ie"},	/* Ireland */
+	{274, 2, "is"},	/* Iceland */
+	{276, 2, "al"},	/* Albania (Republic of) */
+	{278, 2, "mt"},	/* Malta */
+	{280, 2, "cy"},	/* Cyprus (Republic of) */
+	{282, 2, "ge"},	/* Georgia */
+	{283, 2, "am"},	/* Armenia (Republic of) */
+	{284, 2, "bg"},	/* Bulgaria (Republic of) */
+	{286, 2, "tr"},	/* Turkey */
+	{288, 2, "fo"},	/* Faroe Islands */
+	{290, 2, "gl"},	/* Greenland (Denmark) */
+	{292, 2, "sm"},	/* San Marino (Republic of) */
+	{293, 2, "si"},	/* Slovenia (Republic of) */
+	{294, 2, "mk"},	/* The Former Yugoslav Republic of Macedonia */
+	{295, 2, "li"},	/* Liechtenstein (Principality of) */
+	{297, 2, "me"},	/* Montenegro (Republic of) */
+	{302, 3, "ca"},	/* Canada */
+	{308, 2, "pm"},	/* Saint Pierre and Miquelon (french Republic) */
+	{310, 3, "us"},	/* United States of America */
+	{311, 3, "us"},	/* United States of America */
+	{312, 3, "us"},	/* United States of America */
+	{313, 3, "us"},	/* United States of America */
+	{314, 3, "us"},	/* United States of America */
+	{315, 3, "us"},	/* United States of America */
+	{316, 3, "us"},	/* United States of America */
+	{330, 3, "pr"},	/* Puerto Rico */
+	{332, 3, "vi"},	/* United States Virgin Islands */
+	{334, 3, "mx"},	/* Mexico */
+	{338, 3, "jm"},	/* Jamaica */
+	{340, 2, "gp"},	/* Guadeloupe and Martinique (French Departments) */
+	{342, 3, "bb"},	/* Barbados */
+	{344, 3, "ag"},	/* Antigua and Barbuda */
+	{346, 3, "ky"},	/* Cayman Islands */
+	{348, 3, "vg"},	/* British Virgin Islands */
+	{350, 3, "bm"},	/* Bermuda */
+	{352, 3, "gd"},	/* Grenada */
+	{354, 3, "ms"},	/* Montserrat */
+	{356, 3, "kn"},	/* Saint Kitts and Nevis */
+	{358, 3, "lc"},	/* Saint Lucia */
+	{360, 3, "vc"},	/* Saint Vincent and the Grenadines */
+	{362, 2, "ai"},	/* Curazao, St Maarten, Bonaire, St Eustatius, Saba */
+	{363, 2, "aw"},	/* Aruba */
+	{364, 3, "bs"},	/* Bahamas (Commonwealth of the) */
+	{365, 3, "ai"},	/* Anguilla */
+	{366, 3, "dm"},	/* Dominica (Commonwealth of) */
+	{368, 2, "cu"},	/* Cuba */
+	{370, 2, "do"},	/* Dominican Republic */
+	{372, 2, "ht"},	/* Haiti (Republic of) */
+	{374, 2, "tt"},	/* Trinidad and Tobago */
+	{376, 3, "tc"},	/* Turks and Caicos Islands */
+	{400, 2, "az"},	/* Azerbaijani Republic */
+	{401, 2, "kz"},	/* Kazakhstan (Republic of) */
+	{402, 2, "bt"},	/* Bhutan (Kingdom of) */
+	{404, 2, "in"},	/* India (Republic of) */
+	{405, 2, "in"},	/* India (Republic of) */
+	{406, 2, "pk"},	/* India (Republic of) */
+	{410, 2, "af"},	/* Pakistan (Islamic Republic of) */
+	{412, 2, "lk"},	/* Afghanistan */
+	{413, 2, "mm"},	/* Sri Lanka (Democratic Socialist Republic of) */
+	{414, 2, "lb"},	/* Myanmar (the Republic of the Union of) */
+	{415, 2, "jo"},	/* Lebanon */
+	{416, 2, "sy"},	/* Jordan (Hashemite Kingdom of) */
+	{417, 2, "iq"},	/* Syrian Arab Republic */
+	{418, 2, "kw"},	/* Iraq (Republic of) */
+	{419, 2, "sa"},	/* Kuwait (State of) */
+	{420, 2, "ye"},	/* Saudi Arabia (Kingdom of) */
+	{421, 2, "om"},	/* Yemen (Republic of) */
+	{422, 2, "ps"},	/* Oman (Sultanate of) */
+	{424, 2, "ae"},	/* United Arab Emirates */
+	{425, 2, "il"},	/* Israel (State of) */
+	{426, 2, "bh"},	/* Bahrain (Kingdom of) */
+	{427, 2, "qa"},	/* Qatar (State of) */
+	{428, 2, "mn"},	/* Mongolia */
+	{429, 2, "np"},	/* Nepal (Federal Democratic Republic of) */
+	{430, 2, "ae"},	/* United Arab Emirates */
+	{431, 2, "ae"},	/* United Arab Emirates */
+	{432, 2, "ir"},	/* Iran (Islamic Republic of) */
+	{434, 2, "uz"},	/* Uzbekistan (Republic of) */
+	{436, 2, "tj"},	/* Tajikistan (Republic of) */
+	{437, 2, "kg"},	/* Kyrgyz Republic */
+	{438, 2, "tm"},	/* Turkmenistan */
+	{440, 2, "jp"},	/* Japan */
+	{441, 2, "jp"},	/* Japan */
+	{450, 2, "kr"},	/* Korea (Republic of) */
+	{452, 2, "vn"},	/* Viet Nam (Socialist Republic of) */
+	{454, 2, "hk"},	/* Hong Kong, China */
+	{455, 2, "mo"},	/* Macao, China */
+	{456, 2, "kh"},	/* Cambodia (Kingdom of) */
+	{457, 2, "la"},	/* Lao People's Democratic Republic */
+	{460, 2, "cn"},	/* China (People's Republic of) */
+	{461, 2, "cn"},	/* China (People's Republic of) */
+	{466, 2, "tw"},	/* Taiwan, China */
+	{467, 2, "kp"},	/* Democratic People's Republic of Korea */
+	{470, 2, "bd"},	/* Bangladesh (People's Republic of) */
+	{472, 2, "mv"},	/* Maldives (Republic of) */
+	{502, 2, "my"},	/* Malaysia */
+	{505, 2, "au"},	/* Australia */
+	{510, 2, "id"},	/* Indonesia (Republic of) */
+	{514, 2, "tl"},	/* Democratic Republic of Timor-Leste */
+	{515, 2, "ph"},	/* Philippines (Republic of the) */
+	{520, 2, "th"},	/* Thailand */
+	{525, 2, "sg"},	/* Singapore (Republic of) */
+	{528, 2, "bn"},	/* Brunei Darussalam */
+	{530, 2, "nz"},	/* New Zealand */
+	{536, 2, "mp"},	/* Nauru (Republic of) */
+	{537, 2, "gu"},	/* Papua New Guinea */
+	{539, 2, "nr"},	/* Tonga (Kingdom of) */
+	{540, 2, "pg"},	/* Solomon Islands */
+	{541, 2, "to"},	/* Vanuatu (Republic of) */
+	{542, 2, "sb"},	/* Fiji (Republic of) */
+	{543, 2, "vu"},	/* Wallis and Futuna (french territory) */
+	{544, 2, "fj"},	/* American Samoa */
+	{545, 2, "wf"},	/* Kiribati (Republic of) */
+	{546, 2, "as"},	/* New Caledonia (french territory) */
+	{547, 2, "ki"},	/* French Polynesia (french territory) */
+	{548, 2, "nc"},	/* Cook Islands */
+	{549, 2, "pf"},	/* Samoa (Independent State of) */
+	{550, 2, "ck"},	/* Micronesia (Federated States of) */
+	{551, 2, "ws"},	/* Marshall Islands (Republic of the) */
+	{552, 2, "fm"},	/* Palau (Republic of) */
+	{553, 2, "mh"},	/* Tuvalu */
+	{555, 2, "pw"},	/* Niue */
+	{602, 2, "eg"},	/* Egypt (Arab Republic of) */
+	{603, 2, "dz"},	/* Algeria (People's Democratic Republic of) */
+	{604, 2, "ma"},	/* Morocco (Kingdom of) */
+	{605, 2, "tn"},	/* Tunisia */
+	{606, 2, "ly"},	/* Libya */
+	{607, 2, "gm"},	/* Gambia (Republic of the) */
+	{608, 2, "sn"},	/* Senegal (Republic of) */
+	{609, 2, "mr"},	/* Mauritania (Islamic Republic of) */
+	{610, 2, "ml"},	/* Mali (Republic of) */
+	{611, 2, "gn"},	/* Guinea (Republic of) */
+	{612, 2, "ci"},	/* Ivory Coast (Republic of) */
+	{613, 2, "bf"},	/* Burkina Faso */
+	{614, 2, "ne"},	/* Niger (Republic of the) */
+	{615, 2, "tg"},	/* Togolese Republic */
+	{616, 2, "bj"},	/* Benin (Republic of) */
+	{617, 2, "mu"},	/* Mauritius (Republic of) */
+	{618, 2, "lr"},	/* Liberia (Republic of) */
+	{619, 2, "sl"},	/* Sierra Leone */
+	{620, 2, "gh"},	/* Ghana */
+	{621, 2, "ng"},	/* Nigeria (Federal Republic of) */
+	{622, 2, "td"},	/* Chad (Republic of) */
+	{623, 2, "cf"},	/* Central African Republic */
+	{624, 2, "cm"},	/* Cameroon (Republic of) */
+	{625, 2, "cv"},	/* Cape Verde (Republic of) */
+	{626, 2, "st"},	/* Sao Tome and Principe (Democratic Republic of) */
+	{627, 2, "gq"},	/* Equatorial Guinea (Republic of) */
+	{628, 2, "ga"},	/* Gabonese Republic */
+	{629, 2, "cg"},	/* Congo (Republic of the) */
+	{630, 2, "cg"},	/* Democratic Republic of the Congo */
+	{631, 2, "ao"},	/* Angola (Republic of) */
+	{632, 2, "gw"},	/* Guinea-Bissau (Republic of) */
+	{633, 2, "sc"},	/* Seychelles (Republic of) */
+	{634, 2, "sd"},	/* Sudan (Republic of the) */
+	{635, 2, "rw"},	/* Rwanda (Republic of) */
+	{636, 2, "et"},	/* Ethiopia (Federal Democratic Republic of) */
+	{637, 2, "so"},	/* Somali Democratic Republic */
+	{638, 2, "dj"},	/* Djibouti (Republic of) */
+	{639, 2, "ke"},	/* Kenya (Republic of) */
+	{640, 2, "tz"},	/* Tanzania (United Republic of) */
+	{641, 2, "ug"},	/* Uganda (Republic of) */
+	{642, 2, "bi"},	/* Burundi (Republic of) */
+	{643, 2, "mz"},	/* Mozambique (Republic of) */
+	{645, 2, "zm"},	/* Zambia (Republic of) */
+	{646, 2, "mg"},	/* Madagascar (Republic of) */
+	{647, 2, "re"},	/* French Departments in the Indian Ocean */
+	{648, 2, "zw"},	/* Zimbabwe (Republic of) */
+	{649, 2, "na"},	/* Namibia (Republic of) */
+	{650, 2, "mw"},	/* Malawi */
+	{651, 2, "ls"},	/* Lesotho (Kingdom of) */
+	{652, 2, "bw"},	/* Botswana (Republic of) */
+	{653, 2, "sz"},	/* Swaziland (Kingdom of) */
+	{654, 2, "km"},	/* Comoros (Union of the) */
+	{655, 2, "za"},	/* South Africa (Republic of) */
+	{657, 2, "er"},	/* Eritrea */
+	{658, 2, "sh"},	/* Saint Helena, Ascension and Tristan da Cunha */
+	{659, 2, "ss"},	/* South Sudan (Republic of) */
+	{702, 2, "bz"},	/* Belize */
+	{704, 2, "gt"},	/* Guatemala (Republic of) */
+	{706, 2, "sv"},	/* El Salvador (Republic of) */
+	{708, 3, "hn"},	/* Honduras (Republic of) */
+	{710, 2, "ni"},	/* Nicaragua */
+	{712, 2, "cr"},	/* Costa Rica */
+	{714, 2, "pa"},	/* Panama (Republic of) */
+	{716, 2, "pe"},	/* Peru */
+	{722, 3, "ar"},	/* Argentine Republic */
+	{724, 2, "br"},	/* Brazil (Federative Republic of) */
+	{730, 2, "cl"},	/* Chile */
+	{732, 3, "co"},	/* Colombia (Republic of) */
+	{734, 2, "ve"},	/* Venezuela (Bolivarian Republic of) */
+	{736, 2, "bo"},	/* Bolivia (Plurinational State of) */
+	{738, 2, "gy"},	/* Guyana */
+	{740, 2, "ec"},	/* Ecuador */
+	{742, 2, "gf"},	/* French Guiana (French Department of) */
+	{744, 2, "py"},	/* Paraguay (Republic of) */
+	{746, 2, "sr"},	/* Suriname (Republic of) */
+	{748, 2, "uy"},	/* Uruguay (Eastern Republic of) */
+	{750, 3, "fk"},	/* Falkland Islands (Malvinas) */
+	{901, 2, NULL},	/* International Mobile, shared code */
 };
 
 /*
@@ -359,9 +360,35 @@ static int mnclength_get_mnclength(const char *imsi)
 	return -ENOENT;
 }
 
+static const char *mnclength_get_country_code(const char *mcc)
+{
+	char buf[OFONO_MAX_MCC_LENGTH + 1];
+	char *endp;
+	int mcc_num;
+	struct mcc_mnclength *mcc_res;
+
+	if (mcc == NULL || *mcc == '\0')
+		return NULL;
+
+	strncpy(buf, mcc, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	mcc_num = (int) strtoul(buf, &endp, 10);
+	if (*endp != '\0')
+		return NULL;
+
+	mcc_res = bsearch(&mcc_num, mnclen_db, G_N_ELEMENTS(mnclen_db),
+			sizeof(mnclen_db[0]), comp_mcc);
+	if (mcc_res)
+		return mcc_res->country_code;
+
+	return NULL;
+}
+
 static struct ofono_sim_mnclength_driver mnclength_driver = {
-	.name		= "MNC length",
-	.get_mnclength	= mnclength_get_mnclength
+	.name			= "MNC length",
+	.get_mnclength		= mnclength_get_mnclength,
+	.get_country_code	= mnclength_get_country_code
 };
 
 static int mnclength_init(void)

--- a/src/network.c
+++ b/src/network.c
@@ -1771,6 +1771,17 @@ const char *ofono_netreg_get_mnc(struct ofono_netreg *netreg)
 	return netreg->current_operator->mnc;
 }
 
+const char *ofono_netreg_get_name(struct ofono_netreg *netreg)
+{
+	if (netreg == NULL)
+		return NULL;
+
+	if (netreg->current_operator == NULL)
+		return NULL;
+
+	return netreg->current_operator->name;
+}
+
 int ofono_netreg_driver_register(const struct ofono_netreg_driver *d)
 {
 	DBG("driver: %p, name: %s", d, d->name);

--- a/src/ofono.h
+++ b/src/ofono.h
@@ -521,3 +521,4 @@ ofono_bool_t __ofono_private_network_request(ofono_private_network_cb_t cb,
 #include <ofono/sim-mnclength.h>
 
 int __ofono_sim_mnclength_get_mnclength(const char *imsi);
+const char *__ofono_sim_mnclength_get_country_code(const char *mcc);

--- a/src/sim-mnclength.c
+++ b/src/sim-mnclength.c
@@ -54,6 +54,28 @@ int __ofono_sim_mnclength_get_mnclength(const char *imsi)
 	return mnclen;
 }
 
+const char *__ofono_sim_mnclength_get_country_code(const char *mcc)
+{
+	GSList *d;
+	const char *code;
+
+	for (d = g_drivers; d != NULL; d = d->next) {
+		const struct ofono_sim_mnclength_driver *driver = d->data;
+
+		if (driver->get_country_code == NULL)
+			continue;
+
+		DBG("Calling mnclength plugin '%s'", driver->name);
+
+		if (!(code = driver->get_country_code(mcc)))
+			continue;
+
+		return code;
+	}
+
+	return code;
+}
+
 int ofono_sim_mnclength_driver_register(
 			struct ofono_sim_mnclength_driver *driver)
 {


### PR DESCRIPTION
This pull request adds lines to detect availability of __libandroid-properties__ from __libhybris__ and, if available, sets standard android telephony properties accordingly.

Supported properties so far are:
1. __gsm.version.baseband__
2. __gsm.sim.state__
3. __gsm.sim.operator.alpha__
4. __gsm.sim.operator.numeric__
5. __gsm.sim.operator.iso-country__
6. __gsm.network.type__
7. __gsm.operator.alpha__
8. __gsm.operator.numeric__
9. __gsm.operator.iso-country__
10. __gsm.operator.isroaming__

Not supported are:
1. __gsm.version.ril-impl__: set by rild
2. __operator.ismanual__: never set in AOSP
3. __telephony.lteOnCdmaProductType__
4. __telephony.lteOnCdmaDevice__
5. __gsm.current.phone-type__: to be done when VOICE_RADIO_TECH is supported
6. __ril.cdma.inecmmode__
7. __telephony.sms.receive__
8. __telephony.sms.send__
9. __persist.radio.cdma.msgid__
10. __persist.radio.reset_on_switch__
11. __gsm.nitz.time__
12. __net.ppp.reset-by-timeout__

A detail, but might not be complete, list of such properties is available in https://android.googlesource.com/platform/frameworks/base/+/master/telephony/java/com/android/internal/telephony/TelephonyProperties.java