### PR TITLE
plugins: mnclength missed mcc 289 for Abkhazia

### DIFF
--- a/plugins/mnclength.c
+++ b/plugins/mnclength.c
@@ -96,6 +96,7 @@ static struct mcc_mnclength mnclen_db[] = {
 	{284, 2},	/* Bulgaria (Republic of) */
 	{286, 2},	/* Turkey */
 	{288, 2},	/* Faroe Islands */
+	{289, 2},	/* Abkhazia (Georgia) */
 	{290, 2},	/* Greenland (Denmark) */
 	{292, 2},	/* San Marino (Republic of) */
 	{293, 2},	/* Slovenia (Republic of) */


### PR DESCRIPTION
It's strange that [ITU document](http://www.itu.int/dms_pub/itu-t/opb/sp/T-SP-E.212A-2012-PDF-E.pdf) doesn't have it, but it does exist on other sites, e.g. [Wikipedia](http://en.wikipedia.org/wiki/Mobile_country_code#A) and [mcclist.com](http://mcclist.com/mobile-network-codes-country-codes.asp#A).