### PR TITLE
gril: per message hex dump

### DIFF
--- a/gril/gril.c
+++ b/gril/gril.c
@@ -580,6 +580,9 @@ static void new_bytes(struct ring_buffer *rbuf, gpointer user_data)
 			ring_buffer_read(rbuf, &plen, sizeof plen);
 			len -= sizeof plen;
 
+			g_ril_util_debug_hexdump(TRUE, (guchar *) &plen, sizeof plen,
+							p->debugf, p->debug_data);
+
 			p->cur_parcel_size = plen = ntohl(plen);
 			if (!plen)
 				continue;
@@ -604,6 +607,9 @@ static void new_bytes(struct ring_buffer *rbuf, gpointer user_data)
 
 		/* Copy bytes into message buffer */
 		ring_buffer_read(rbuf, message->buf, plen);
+
+		g_ril_util_debug_hexdump(TRUE, (guchar *) message->buf, plen,
+						p->debugf, p->debug_data);
 
 		dispatch(p, message);
 	}

--- a/gril/gril.c
+++ b/gril/gril.c
@@ -93,6 +93,7 @@ struct ril_s {
 	GHashTable *notify_list;		/* List of notification reg */
 	GRilDisconnectFunc user_disconnect;	/* user disconnect func */
 	gpointer user_disconnect_data;		/* user disconnect data */
+	uint32_t cur_parcel_size;		/* Current parcel size */
 	gboolean suspended;			/* Are we suspended? */
 	GRilDebugFunc debugf;			/* debugging output function */
 	gpointer debug_data;			/* Data to pass to debug func */
@@ -557,100 +558,54 @@ error:
 	g_free(message);
 }
 
-static struct ril_msg *read_fixed_record(struct ril_s *p,
-						const guchar *bytes, gsize *len)
-{
-	struct ril_msg *message;
-	unsigned message_len, plen;
-
-	/* First four bytes are length in TCP byte order (Big Endian) */
-	plen = ntohl(*((uint32_t *) (void *) bytes));
-	bytes += 4;
-
-	/* TODO: Verify that 4k is the max message size from rild.
-	 *
-	 * These conditions shouldn't happen.  If it does
-	 * there are three options:
-	 *
-	 * 1) ASSERT; ofono will restart via DBus
-	 * 2) Consume the bytes & continue
-	 * 3) force a disconnect
-	 */
-	g_assert(plen >= 8 && plen <= 4092);
-
-	/* If we don't have the whole fixed record in the ringbuffer
-	 * then return NULL & leave ringbuffer as is.
-	*/
-
-	message_len = *len - 4;
-	if (message_len < plen) {
-		DBG("Not enough bytes for fixed record; len: %d avail: %d",
-			plen, message_len);
-		return NULL;
-	}
-
-	/* FIXME: add check for message_len = 0? */
-
-	message = g_try_malloc(sizeof(struct ril_msg));
-	g_assert(message != NULL);
-
-	/* allocate ril_msg->buffer */
-	message->buf_len = plen;
-	message->buf = g_try_malloc(plen);
-	g_assert(message->buf != NULL);
-
-	/* Copy bytes into message buffer */
-	memmove(message->buf, (const void *) bytes, plen);
-
-	/* Indicate to caller size of record we extracted */
-	*len = plen + 4;
-	return message;
-}
-
 static void new_bytes(struct ring_buffer *rbuf, gpointer user_data)
 {
 	struct ril_msg *message;
 	struct ril_s *p = user_data;
-	unsigned int len = ring_buffer_len(rbuf);
-	unsigned int wrap = ring_buffer_len_no_wrap(rbuf);
-	guchar *buf = ring_buffer_read_ptr(rbuf, 0);
+	unsigned int len;
+	uint32_t plen;
 
 	p->in_read_handler = TRUE;
 
-	while (p->suspended == FALSE && len) {
-		gsize rbytes = wrap;
+	while (p->suspended == FALSE) {
+		plen = p->cur_parcel_size;
+		len = ring_buffer_len(rbuf);
 
-		if (rbytes < 4) {
-			DBG("Not enough bytes for header length: len: %d", len);
-			return;
+		if (!plen) {
+			if (len < 4) {
+				DBG("Not enough bytes for header length: len: %d", len);
+				break;
+			}
+
+			ring_buffer_read(rbuf, &plen, sizeof plen);
+			len -= sizeof plen;
+
+			p->cur_parcel_size = plen = ntohl(plen);
+			if (!plen)
+				continue;
 		}
 
-		/* this function attempts to read the next full length
-		 * fixed message from the stream.  if not all bytes are
-		 * available, it returns NULL.  otherwise it allocates
-		 * and returns a ril_message with the copied bytes, and
-		 * drains those bytes from the ring_buffer
-		 */
-		message = read_fixed_record(p, buf, &rbytes);
-
-		/* wait for the rest of the record... */
-		if (message == NULL)
+		if (len < plen) {
+			DBG("Not enough bytes for fixed record; len: %d avail: %d",
+				plen, len);
 			break;
-
-		buf += rbytes;
-
-		/* TODO: need to better understand how wrap works! */
-		if (rbytes == wrap) {
-			buf = ring_buffer_read_ptr(rbuf, rbytes);
-			wrap = len;
 		}
+
+		/* Reset for next parcel. */
+		p->cur_parcel_size = 0;
+
+		message = g_try_malloc(sizeof(struct ril_msg));
+		g_assert(message != NULL);
+
+		/* allocate ril_msg->buffer */
+		message->buf_len = plen;
+		message->buf = g_try_malloc(plen);
+		g_assert(message->buf != NULL);
+
+		/* Copy bytes into message buffer */
+		ring_buffer_read(rbuf, message->buf, plen);
 
 		dispatch(p, message);
-
-		ring_buffer_drain(rbuf, rbytes);
-
-		len -= rbytes;
-		wrap -= rbytes;
 	}
 
 	p->in_read_handler = FALSE;

--- a/gril/grilio.c
+++ b/gril/grilio.c
@@ -115,9 +115,6 @@ static gboolean received_data(GIOChannel *channel, GIOCondition cond,
 
 		ring_buffer_write_advance(io->buf, rbytes);
 
-		g_ril_util_debug_hexdump(TRUE, (guchar *) buf, rbytes,
-						io->debugf, io->debug_data);
-
 		/* Try to dispatch all the incoming parcels so that we may get
 		 * some more space to read again.
 		 */


### PR DESCRIPTION
With **OFONO_RIL_HEX_TRACE** set and exported, gril begins to dump raw stream in hex. However, one such trace dump may contain several RIL messages or even an incomplete one. This patch moves such dump from grilio to gril so that hex dumps are only printed after being parsed as a complete RIL message.

This is for https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1331183 .
