### PR TITLE
Force only one slot with ConnectionManager.Powered set

### DIFF
--- a/include/modem.h
+++ b/include/modem.h
@@ -69,6 +69,9 @@ struct ofono_modem_driver {
 
 	/* Populate the atoms available online */
 	void (*post_online)(struct ofono_modem *modem);
+
+	/* Is it a multi-SIM standby modem? */
+	ofono_bool_t (*is_standby)(struct ofono_modem *modem);
 };
 
 void ofono_modem_add_interface(struct ofono_modem *modem,
@@ -115,6 +118,8 @@ ofono_bool_t ofono_modem_get_boolean(struct ofono_modem *modem,
 void ofono_modem_set_driver_watches_sim(struct ofono_modem *modem,
 					ofono_bool_t value);
 ofono_bool_t ofono_modem_get_driver_watches_sim(struct ofono_modem *modem);
+
+ofono_bool_t ofono_modem_is_standby(struct ofono_modem *modem);
 
 int ofono_modem_driver_register(const struct ofono_modem_driver *);
 void ofono_modem_driver_unregister(const struct ofono_modem_driver *);

--- a/plugins/mtk.c
+++ b/plugins/mtk.c
@@ -1659,6 +1659,11 @@ static int mtk_disable(struct ofono_modem *modem)
 	return 0;
 }
 
+static ofono_bool_t mtk_is_standby(struct ofono_modem *modem)
+{
+	return TRUE;
+}
+
 static struct ofono_modem_driver mtk_driver = {
 	.name = "mtk",
 	.probe = mtk_probe,
@@ -1669,6 +1674,7 @@ static struct ofono_modem_driver mtk_driver = {
 	.post_sim = mtk_post_sim,
 	.post_online = mtk_post_online,
 	.set_online = mtk_set_online,
+	.is_standby = mtk_is_standby,
 };
 
 static int mtk_init(void)

--- a/src/modem.c
+++ b/src/modem.c
@@ -2256,3 +2256,11 @@ void __ofono_modem_dec_emergency_mode(struct ofono_modem *modem)
 out:
 	modem->emergency--;
 }
+
+ofono_bool_t ofono_modem_is_standby(struct ofono_modem *modem)
+{
+	if (modem->driver->is_standby == NULL)
+		return FALSE;
+
+	return modem->driver->is_standby(modem);
+}


### PR DESCRIPTION
This changes forces settings so only one slot can have ConnectionManager.Powered set at a time, for multi-sim dual-standby devices.