### PR TITLE
mtkmodem: Fix failure to answer fast a call

### DIFF
--- a/drivers/mtkmodem/voicecall.c
+++ b/drivers/mtkmodem/voicecall.c
@@ -57,15 +57,11 @@ static void mtk_set_indication_cb(struct ril_msg *message, gpointer user_data)
 	struct ofono_voicecall *vc = user_data;
 	struct ril_voicecall_data *vd = ofono_voicecall_get_data(vc);
 
-	if (message->error == RIL_E_SUCCESS) {
+	if (message->error == RIL_E_SUCCESS)
 		g_ril_print_response_no_args(vd->ril, message);
-
-		/* Request the call list again */
-		ril_poll_clcc(vc);
-	} else {
+	else
 		ofono_error("%s: RIL error %s", __func__,
 				ril_error_to_string(message->error));
-	}
 }
 
 static void mtk_incoming_notify(struct ril_msg *message, gpointer user_data)


### PR DESCRIPTION
When an incoming call was being answered immediately after it appearead, RIL_REQUEST_ANSWER was sent and the reply indicated success, but the call was not actually transitioning to the active state. This is a bug in rild because the modem was responding with error "+CME: 3" to the "ATA" command, but nonetheless there is a also bug in ofono because we are letting the user answer the call before the modem is ready. To avoid this, we do not poll for the calls after sending an MTK_CALL_INDIC_MODE_AVAIL, but wait for the MTK_RIL_UNSOL_CALL_PROGRESS_INFO that indicates that the modem is ready to do so.