### PR TITLE
rilmodem/sim: validate returned gsm app_index

### DIFF
--- a/drivers/rilmodem/sim.c
+++ b/drivers/rilmodem/sim.c
@@ -664,7 +664,10 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 				__func__, status->card_state);
 
 	/* TODO(CDMA): need some kind of logic to set the correct app_index */
-	search_index = status->gsm_umts_index;
+	if (status->gsm_umts_index < 0)
+		search_index = 0;
+	else
+		search_index = status->gsm_umts_index;
 
 	/*
 	 * We cache the current password state. Ideally this should be done by

--- a/gril/grilreply.h
+++ b/gril/grilreply.h
@@ -80,9 +80,9 @@ struct reply_sim_app {
 struct reply_sim_status {
 	guint card_state;
 	guint pin_state;
-	guint gsm_umts_index;
-	guint cdma_index;
-	guint ims_index;
+	int gsm_umts_index;
+	int cdma_index;
+	int ims_index;
 	guint num_apps;
 	struct reply_sim_app *apps[MAX_UICC_APPS];
 };


### PR DESCRIPTION
Check gsm app index returned by the GET_SIM_INFO reply to ensure it's not negative, if it is, set it to zero.

This fixes:

https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1427788