### PR TITLE
Make PIN retries always available for MTK modems

### DIFF
--- a/gril/grilreply.c
+++ b/gril/grilreply.c
@@ -1428,3 +1428,35 @@ struct reply_oem_hook *g_ril_reply_oem_hook_raw(GRil *gril,
 end:
 	return reply;
 }
+
+struct parcel_str_array *g_ril_reply_oem_hook_strings(GRil *gril,
+						const struct ril_msg *message)
+{
+	struct parcel rilp;
+	struct parcel_str_array *str_arr;
+	int i;
+
+	g_ril_init_parcel(message, &rilp);
+
+	str_arr = parcel_r_str_array(&rilp);
+	if (str_arr == NULL) {
+		ofono_error("%s: no strings", __func__);
+		goto out;
+	}
+
+	g_ril_append_print_buf(gril, "{");
+
+	for (i = 0; i < str_arr->num_str; ++i) {
+		if (i + 1 == str_arr->num_str)
+			g_ril_append_print_buf(gril, "%s%s}", print_buf,
+						str_arr->str[i]);
+		else
+			g_ril_append_print_buf(gril, "%s%s, ", print_buf,
+						str_arr->str[i]);
+	}
+
+	g_ril_print_response(gril, message);
+
+out:
+	return str_arr;
+}

--- a/gril/grilreply.h
+++ b/gril/grilreply.h
@@ -175,6 +175,9 @@ void g_ril_reply_free_oem_hook(struct reply_oem_hook *oem_hook);
 struct reply_oem_hook *g_ril_reply_oem_hook_raw(GRil *gril,
 						const struct ril_msg *message);
 
+struct parcel_str_array *g_ril_reply_oem_hook_strings(GRil *gril,
+						const struct ril_msg *message);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gril/grilrequest.c
+++ b/gril/grilrequest.c
@@ -1073,6 +1073,28 @@ void g_ril_request_oem_hook_raw(GRil *gril, const void *payload, size_t length,
 	g_free(hex_dump);
 }
 
+void g_ril_request_oem_hook_strings(GRil *gril, const char **strs, int num_str,
+							struct parcel *rilp)
+{
+	int i;
+
+	parcel_init(rilp);
+	parcel_w_int32(rilp, num_str);
+
+	g_ril_append_print_buf(gril, "(");
+
+	for (i = 0; i < num_str; ++i) {
+		parcel_w_string(rilp, strs[i]);
+
+		if (i == num_str - 1)
+			g_ril_append_print_buf(gril, "%s%s)",
+							print_buf, strs[i]);
+		else
+			g_ril_append_print_buf(gril, "%s%s, ",
+							print_buf, strs[i]);
+	}
+}
+
 void g_ril_request_set_initial_attach_apn(GRil *gril, const char *apn,
 						int proto,
 						const char *user,

--- a/gril/grilrequest.h
+++ b/gril/grilrequest.h
@@ -269,6 +269,9 @@ void g_ril_request_change_barring_password(GRil *gril, const char *facility,
 void g_ril_request_oem_hook_raw(GRil *gril, const void *payload, size_t length,
 					struct parcel *rilp);
 
+void g_ril_request_oem_hook_strings(GRil *gril, const char **strs, int num_str,
+							struct parcel *rilp);
+
 void g_ril_request_set_initial_attach_apn(GRil *gril, const char *apn,
 						int proto,
 						const char *user,

--- a/unit/test-grilrequest.c
+++ b/unit/test-grilrequest.c
@@ -855,6 +855,32 @@ static const struct request_test_set_initial_attach_apn
 	.parcel_size = sizeof(req_set_initial_attach_apn_valid_1),
 };
 
+/* oem_hook_strings tests */
+
+struct request_test_oem_hook_strings {
+	const int num_str;
+	const char **str;
+	const guchar *parcel_data;
+	gsize parcel_size;
+};
+
+static const guchar req_oem_hook_strings_valid_1[] = {
+	0x02, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x41, 0x00, 0x54, 0x00,
+	0x2b, 0x00, 0x45, 0x00, 0x50, 0x00, 0x49, 0x00, 0x4e, 0x00, 0x43, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x2b, 0x00, 0x45, 0x00,
+	0x50, 0x00, 0x49, 0x00, 0x4e, 0x00, 0x43, 0x00, 0x3a, 0x00, 0x00, 0x00
+};
+
+static const char *oem_hook_strings_valid_1[] = { "AT+EPINC", "+EPINC:" };
+
+static const struct request_test_oem_hook_strings
+					oem_hook_strings_valid_test_1 = {
+	.num_str = G_N_ELEMENTS(oem_hook_strings_valid_1),
+	.str = oem_hook_strings_valid_1,
+	.parcel_data = req_oem_hook_strings_valid_1,
+	.parcel_size = sizeof(req_oem_hook_strings_valid_1),
+};
+
 /*
  * The following hexadecimal data represents a serialized Binder parcel
  * instance containing a valid RIL_REQUEST_RADIO_POWER 'OFF' message.
@@ -1418,6 +1444,20 @@ static void test_request_oem_hook_raw(gconstpointer data)
 	parcel_free(&rilp);
 }
 
+static void test_request_oem_hook_strings(gconstpointer data)
+{
+	const struct request_test_oem_hook_strings *test_data = data;
+	struct parcel rilp;
+
+	g_ril_request_oem_hook_strings(NULL, test_data->str,
+					test_data->num_str, &rilp);
+
+	g_assert(!memcmp(rilp.data, test_data->parcel_data,
+				test_data->parcel_size));
+
+	parcel_free(&rilp);
+}
+
 #endif
 
 int main(int argc, char **argv)
@@ -1681,6 +1721,12 @@ int main(int argc, char **argv)
 				"valid SET_INITIAL_ATTACH_APN Test 1",
 				&set_initial_attach_apn_valid_test_1,
 				test_request_set_initial_attach_apn);
+
+	g_test_add_data_func("/testgrilrequest/oem-hook-strings: "
+				"valid OEM_HOOK_STRINGS Test 1",
+				&oem_hook_strings_valid_test_1,
+				test_request_oem_hook_strings);
+
 #endif
 	return g_test_run();
 }


### PR DESCRIPTION
Use AT+EPINC command to get available retries for PIN, PIN2, PUK, and PUK2 for MTK modems. This way we can know the available retries even when we have not tried to enter any password yet. This PR fixes

https://bugs.launchpad.net/ubuntu/+source/indicator-network/+bug/1436820/