### PR TITLE
Provision APNs without explicit type

### DIFF
--- a/plugins/ubuntu-apndb.c
+++ b/plugins/ubuntu-apndb.c
@@ -192,7 +192,8 @@ static enum ofono_gprs_context_type determine_apn_type(const char *types)
 	 */
 
 	/* Default apns can be used for mms and ia, mms can be used for ia */
-	if (strstr(types, "default") != NULL)
+	if (types == NULL || g_strcmp0(types, "*") == 0
+					|| strstr(types, "default") != NULL)
 		return OFONO_GPRS_CONTEXT_TYPE_INTERNET;
 	else if (strstr(types, "mms") != NULL)
 		return OFONO_GPRS_CONTEXT_TYPE_MMS;
@@ -341,12 +342,6 @@ static void toplevel_apndb_start(GMarkupParseContext *context,
 		return;
 	}
 
-	if (types == NULL) {
-		ofono_error("%s: apn for %s missing type attribute", __func__,
-				carrier);
-		return;
-	}
-
 	if (protocol != NULL) {
 		if (g_strcmp0(protocol, "IP") == 0) {
 			proto = OFONO_GPRS_PROTO_IP;
@@ -404,7 +399,8 @@ static void toplevel_apndb_start(GMarkupParseContext *context,
 
 	if (type == OFONO_GPRS_CONTEXT_TYPE_ANY ||
 		(type == OFONO_GPRS_CONTEXT_TYPE_MMS && mmscenter == NULL)) {
-		DBG("Skipping %s context; types: %s", apn, types);
+		DBG("Skipping %s context; types: %s",
+					apn, types ? types : "(null)");
 		return;
 	}
 


### PR DESCRIPTION
Provision APN entries that do not explicitly set the type or when type="*". In the AOSP code this is equivalent to an APN valid for all types, so we do the same here. See

https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1437200