### PR TITLE
Add Preferred property to contexts

### DIFF
--- a/doc/connman-api.txt
+++ b/doc/connman-api.txt
@@ -203,6 +203,14 @@ Properties	boolean Active [readwrite]
 			context.  The name should not be empty and limited
 			to a short string for display purposes.
 
+		boolean Preferred [readwrite]
+
+			Holds a boolean.  This value is meant to be used by
+			clients to store an indication on whether this context
+			is preferred compared to others.  ofono just stores and
+			shows this value, but does not use it internally. The
+			exact way in which this is used depends on the clients.
+
 		dict Settings [readonly, optional]
 
 			Holds all the IP network settings

--- a/src/gprs.c
+++ b/src/gprs.c
@@ -124,6 +124,7 @@ struct ofono_gprs_context {
 struct pri_context {
 	ofono_bool_t active;
 	enum ofono_gprs_context_type type;
+	gboolean preferred;
 	char name[MAX_CONTEXT_NAME_LENGTH + 1];
 	char message_proxy[MAX_MESSAGE_PROXY_LENGTH + 1];
 	char message_center[MAX_MESSAGE_CENTER_LENGTH + 1];
@@ -758,7 +759,7 @@ static void append_context_properties(struct pri_context *ctx,
 	const char *type = gprs_context_type_to_string(ctx->type);
 	const char *proto = gprs_proto_to_string(ctx->context.proto);
 	const char *name = ctx->name;
-	dbus_bool_t value;
+	dbus_bool_t value, preferred;
 	const char *strvalue;
 	struct context_settings *settings;
 
@@ -766,6 +767,9 @@ static void append_context_properties(struct pri_context *ctx,
 
 	value = ctx->active;
 	ofono_dbus_dict_append(dict, "Active", DBUS_TYPE_BOOLEAN, &value);
+
+	preferred = ctx->preferred;
+	ofono_dbus_dict_append(dict, "Preferred", DBUS_TYPE_BOOLEAN, &preferred);
 
 	ofono_dbus_dict_append(dict, "Type", DBUS_TYPE_STRING, &type);
 
@@ -890,6 +894,33 @@ static void pri_deactivate_callback(const struct ofono_error *error, void *data)
 	ofono_dbus_signal_property_changed(conn, ctx->path,
 					OFONO_CONNECTION_CONTEXT_INTERFACE,
 					"Active", DBUS_TYPE_BOOLEAN, &value);
+}
+
+static DBusMessage *pri_set_preferred(struct pri_context *ctx,
+					DBusConnection *conn,
+					DBusMessage *msg, gboolean preferred)
+{
+	GKeyFile *settings = ctx->gprs->settings;
+
+	if (ctx->preferred == preferred)
+		return dbus_message_new_method_return(msg);
+
+	ctx->preferred = preferred;
+
+	if (settings) {
+		g_key_file_set_boolean(settings, ctx->key, "Preferred",
+								preferred);
+		storage_sync(ctx->gprs->imsi, SETTINGS_STORE, settings);
+	}
+
+	g_dbus_send_reply(conn, msg, DBUS_TYPE_INVALID);
+
+	ofono_dbus_signal_property_changed(conn, ctx->path,
+					OFONO_CONNECTION_CONTEXT_INTERFACE,
+					"Preferred", DBUS_TYPE_BOOLEAN,
+					&preferred);
+
+	return NULL;
 }
 
 static DBusMessage *pri_set_apn(struct pri_context *ctx, DBusConnection *conn,
@@ -1188,6 +1219,15 @@ static DBusMessage *pri_set_property(DBusConnection *conn,
 						pri_deactivate_callback, ctx);
 
 		return NULL;
+	}
+
+	if (!strcmp(property, "Preferred")) {
+		if (dbus_message_iter_get_arg_type(&var) != DBUS_TYPE_BOOLEAN)
+			return __ofono_error_invalid_args(msg);
+
+		dbus_message_iter_get_basic(&var, &value);
+
+		return pri_set_preferred(ctx, conn, msg, value);
 	}
 
 	/* All other properties are read-only when context is active */
@@ -1736,6 +1776,8 @@ static void write_context_settings(struct ofono_gprs *gprs,
 				gprs_context_type_to_string(context->type));
 	g_key_file_set_string(gprs->settings, context->key, "Protocol",
 				gprs_proto_to_string(context->context.proto));
+	g_key_file_set_boolean(gprs->settings, context->key, "Preferred",
+				context->preferred);
 
 	if (context->type == OFONO_GPRS_CONTEXT_TYPE_MMS ||
 		(context->message_center && strlen(context->message_center) > 0)) {
@@ -2690,6 +2732,7 @@ static gboolean load_context(struct ofono_gprs *gprs, const char *group)
 	char *msgcenter = NULL;
 	gboolean ret = FALSE;
 	gboolean legacy = FALSE;
+	gboolean preferred;
 	struct pri_context *context;
 	enum ofono_gprs_context_type type;
 	enum ofono_gprs_proto proto;
@@ -2723,6 +2766,9 @@ static gboolean load_context(struct ofono_gprs *gprs, const char *group)
 
 	if (gprs_proto_from_string(protostr, &proto) == FALSE)
 		goto error;
+
+	preferred = g_key_file_get_boolean(gprs->settings, group,
+							"Preferred", NULL);
 
 	username = g_key_file_get_string(gprs->settings, group,
 						"Username", NULL);
@@ -2775,6 +2821,7 @@ static gboolean load_context(struct ofono_gprs *gprs, const char *group)
 	strcpy(context->context.password, password);
 	strcpy(context->context.apn, apn);
 	context->context.proto = proto;
+	context->preferred = preferred;
 
 	if (msgproxy != NULL)
 		strcpy(context->message_proxy, msgproxy);


### PR DESCRIPTION
Add Preferred property to org.ofono.ConnectionContext. This property is a way to express that a context is preferred over the others for activation. It is a facility used by the ofono clients, but it is not actually used internally.

See

https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1361864

for more information.