### PR TITLE
Reset contexts

### DIFF
--- a/doc/connman-api.txt
+++ b/doc/connman-api.txt
@@ -60,6 +60,16 @@ Methods		dict GetProperties()
 					 [service].Error.NotFound
 					 [service].Error.Failed
 
+		void ResetContexts()
+
+			Removes all contexts and re-provisions from the APN
+			database. Contexts must all be deactivated for this
+			method to work.
+
+			Possible Errors: [service].Error.InProgress
+					 [service].Error.InvalidArguments
+					 [service].Error.NotAllowed
+
 Signals		PropertyChanged(string property, variant value)
 
 			This signal indicates a changed value of the given

--- a/test/reset-contexts
+++ b/test/reset-contexts
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import dbus
+import sys
+
+bus = dbus.SystemBus()
+
+if len(sys.argv) == 2:
+	path = sys.argv[1]
+else:
+	manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+			'org.ofono.Manager')
+	modems = manager.GetModems()
+	path = modems[0][0]
+
+print("Resetting contexts for SIM on modem %s..." % path)
+cm = dbus.Interface(bus.get_object('org.ofono', path),
+		'org.ofono.ConnectionManager')
+
+cm.ResetContexts()


### PR DESCRIPTION
Add ResetContexts method to org.ofono.ConnectionManager interface. This method removes all current contexts and runs re-provisioning. Fix for

https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1338758