### PR TITLE
test/rilmodem/sim: fix scripts on arale

### DIFF
--- a/test/rilmodem/sim/simtestutil.py
+++ b/test/rilmodem/sim/simtestutil.py
@@ -176,7 +176,7 @@ class SimTestCase(unittest.TestCase):
 							path),
 							'org.ofono.SimManager')
 	def if_supports_sim_offline(self):
-		if self.product != "krillin":
+		if self.product != "krillin" and self.product != "arale":
 			return True
 		else:
 			return False
@@ -225,7 +225,7 @@ class SimTestCase(unittest.TestCase):
 			else:
                                 check_features = no_sim_online_features[:]
 		else:
-			if self.product == "krillin":
+			if self.product == "krillin" or self.product == "arale":
 				check_features = []
 			else:
 				if test_sims:
@@ -264,7 +264,7 @@ class SimTestCase(unittest.TestCase):
 		else:
 
 			# krillin no diff between sim/no-SIM when offline
-			if self.product == "krillin":
+			if self.product == "krillin" or self.product == "arale":
 				check_ifaces = no_sim_offline_ifaces[:]
 				check_ifaces.append("org.ofono.NetworkTime")
 			else:
@@ -298,7 +298,7 @@ class SimTestCase(unittest.TestCase):
 		#
 		# https://bugs.launchpad.net/ubuntu/+source/ofono/+bug/1396317
 
-		if self.product == "krillin":
+		if self.product == "krillin" or self.product == "arale":
 			self.assertTrue(properties["Muted"] == 0)
 		else:
 			self.assertTrue(properties["Muted"] == 1)

--- a/test/rilmodem/sim/test-no-sims-offline
+++ b/test/rilmodem/sim/test-no-sims-offline
@@ -67,7 +67,7 @@ class TestNoSimsOffline(SimTestCase):
 		self.validate_modem_properties(path, False, False)
 
 		# krillin doesn't expose SimManager when offline
-		if (self.product != "krillin"):
+		if (self.product != "krillin" and self.product != "arale"):
 			self.assertTrue(self.check_no_sim_present(path))
 
 		self.validate_emergency_numbers(path)

--- a/test/rilmodem/sim/test-sims-offline
+++ b/test/rilmodem/sim/test-sims-offline
@@ -89,7 +89,7 @@ class TestSimsOffline(SimTestCase):
 		self.validate_modem_properties(path, False, True)
 
 		# krillin: no SIM access when modem offline
-		if (self.product != "krillin"):
+		if (self.product != "krillin" and self.product != "arale"):
 			self.validate_sim_properties(path, self.args.mcc,
 							self.args.mnc,
 							self.args.subscriber)


### PR DESCRIPTION
Fix SIM test scripts when run on arale.  Fix for:

https://bugs.launchpad.net/ubuntu-rtm/+source/ofono/+bug/1457775
