### PR TITLE
Make qcom-msim plugin able to use other SIM slot than first SIM slot.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,6 +168,10 @@ builtin_sources += drivers/rilmodem/rilmodem.h \
 			drivers/rilmodem/radio-settings.c \
 			drivers/rilmodem/call-barring.c \
 			drivers/rilmodem/phonebook.c
+
+builtin_modules += qcommsimmodem
+builtin_sources += drivers/qcommsimmodem/qcom_msim_modem.c \
+			drivers/qcommsimmodem/radio-settings.c
 endif
 
 if ISIMODEM

--- a/drivers/qcommsimmodem/qcom_msim_modem.c
+++ b/drivers/qcommsimmodem/qcom_msim_modem.c
@@ -1,0 +1,56 @@
+/*
+ *
+ *  oFono - Open Source Telephony - RIL Modem Support
+ *
+ *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2012 Canonical, Ltd. All rights reserved.
+ *  Copyright (C) 2015 Ratchanan Srirattanamet.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <glib.h>
+#include <gril.h>
+
+#define OFONO_API_SUBJECT_TO_CHANGE
+#include <ofono/plugin.h>
+#include <ofono/log.h>
+#include <ofono/types.h>
+
+#include "qcom_msim_modem.h"
+
+static int qcom_msim_modem_init(void)
+{
+	DBG("");
+
+	qcom_msim_radio_settings_init();
+
+	return 0;
+}
+
+static void qcom_msim_modem_exit(void)
+{
+	DBG("");
+
+	qcom_msim_radio_settings_exit();
+}
+
+OFONO_PLUGIN_DEFINE(qcommsimmodem, "Qualcomm multi-sim modem driver", VERSION,
+				OFONO_PLUGIN_PRIORITY_DEFAULT,
+				qcom_msim_modem_init, qcom_msim_modem_exit)

--- a/drivers/qcommsimmodem/qcom_msim_modem.h
+++ b/drivers/qcommsimmodem/qcom_msim_modem.h
@@ -1,8 +1,8 @@
 /*
  *
- *  RIL constants for Qualcomm multi-sim modem
+ *  oFono - Open Source Telephony - RIL Modem Support
  *
- *  Copyright (C) 2015 Ratchanan Srirattanamet.
+ *  Copyright (C) 2015 Ratchanan Srirattanamet
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -19,11 +19,7 @@
  *
  */
 
-#ifndef QCOM_MSIM_CONSTANTS_H
-#define QCOM_MSIM_CONSTANTS_H
+#define QCOMMSIMMODEM "qcommsimmodem"
 
-#define QCOMMSIM_NUM_SLOTS_MAX 2
-
-#define QCOM_MSIM_RIL_REQUEST_SET_UICC_SUBSCRIPTION  115
-
-#endif /* QCOM_MSIM_CONSTANTS_H */
+extern void qcom_msim_radio_settings_init(void);
+extern void qcom_msim_radio_settings_exit(void);

--- a/drivers/qcommsimmodem/radio-settings.c
+++ b/drivers/qcommsimmodem/radio-settings.c
@@ -1,0 +1,270 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2014  Canonical Ltd.
+ *  Copyright (C) 2015 Ratchanan Srirattanamet
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <glib.h>
+
+#include <ofono/log.h>
+#include <ofono/modem.h>
+#include <ofono/radio-settings.h>
+
+#include "gril.h"
+#include "grilrequest.h"
+#include "grilreply.h"
+
+#include "drivers/rilmodem/radio-settings.h"
+#include "drivers/rilmodem/rilutil.h"
+#include "qcom_msim_modem.h"
+#include "qcom_msim_constants.h"
+
+struct qcom_msim_pending_pref_setting {
+	struct ofono_radio_settings *rs;
+	int pref;
+	int pending_gsm_pref_remaining;
+	struct cb_data *cbd;
+};
+
+struct qcom_msim_set_2g_rat {
+	struct ofono_radio_settings *rs;
+	struct qcom_msim_pending_pref_setting *pps;
+};
+
+static struct ofono_radio_settings *multisim_rs[QCOMMSIM_NUM_SLOTS_MAX];
+static int multisim_num_slots;
+
+static void qcom_msim_set_rat_cb(struct ril_msg *message, gpointer user_data)
+{
+	struct cb_data *cbd = user_data;
+	struct ofono_radio_settings *rs = cbd->user;
+	struct radio_data *rd = ofono_radio_settings_get_data(rs);
+	ofono_radio_settings_rat_mode_set_cb_t cb = cbd->cb;
+
+	if (message->error == RIL_E_SUCCESS) {
+		g_ril_print_response_no_args(rd->ril, message);
+		CALLBACK_WITH_SUCCESS(cb, cbd->data);
+	} else {
+		ofono_error("%s: rat mode setting failed", __func__);
+		CALLBACK_WITH_FAILURE(cb, cbd->data);
+	}
+}
+
+static void qcom_msim_set_2g_rat_cb(struct ril_msg *message,
+							gpointer user_data)
+{
+	struct qcom_msim_set_2g_rat *set_2g_rat_data = user_data;
+	struct ofono_radio_settings *rs = set_2g_rat_data->rs;
+	struct qcom_msim_pending_pref_setting *pps = set_2g_rat_data->pps;
+	struct radio_data *rd = ofono_radio_settings_get_data(rs);
+	ofono_radio_settings_rat_mode_set_cb_t cb;
+	struct parcel rilp;
+
+	pps->pending_gsm_pref_remaining -= 1;
+
+	if (message->error == RIL_E_SUCCESS) {
+		g_ril_print_response_no_args(rd->ril, message);
+		ofono_radio_settings_set_rat_mode(rs,
+						OFONO_RADIO_ACCESS_MODE_GSM);
+	} else {
+		ofono_error("%s: rat mode setting failed", __func__);
+		if (pps->cbd != NULL) {
+			cb = pps->cbd->cb;
+			CALLBACK_WITH_FAILURE(cb, pps->cbd->data);
+
+			g_free(pps->cbd);
+			pps->cbd = NULL;
+		}
+	}
+
+	if (pps->pending_gsm_pref_remaining == 0) {
+		if (pps->cbd != NULL) {
+			struct radio_data *pps_rd =
+					ofono_radio_settings_get_data(pps->rs);
+			g_ril_request_set_preferred_network_type(pps_rd->ril,
+							pps->pref, &rilp);
+
+			if (g_ril_send(pps_rd->ril,
+					RIL_REQUEST_SET_PREFERRED_NETWORK_TYPE,
+					&rilp, qcom_msim_set_rat_cb, pps->cbd,
+					g_free) == 0) {
+				ofono_error("%s: unable to set rat mode",
+								__func__);
+				cb = pps->cbd->cb;
+				CALLBACK_WITH_FAILURE(cb, pps->cbd->data);
+				g_free(pps->cbd);
+			}
+		}
+
+		g_free(pps);
+	}
+}
+
+static void qcom_msim_set_rat_mode(struct ofono_radio_settings *rs,
+			enum ofono_radio_access_mode mode,
+			ofono_radio_settings_rat_mode_set_cb_t cb,
+			void *data)
+{
+	struct radio_data *rd = ofono_radio_settings_get_data(rs);
+	struct cb_data *cbd = cb_data_new(cb, data, rs);
+	struct parcel rilp;
+	int pref = PREF_NET_TYPE_GSM_WCDMA;
+
+	switch (mode) {
+	case OFONO_RADIO_ACCESS_MODE_ANY:
+		pref = PREF_NET_TYPE_LTE_GSM_WCDMA;
+		break;
+	case OFONO_RADIO_ACCESS_MODE_GSM:
+		pref = PREF_NET_TYPE_GSM_ONLY;
+		break;
+	case OFONO_RADIO_ACCESS_MODE_UMTS:
+		pref = PREF_NET_TYPE_GSM_WCDMA;
+		break;
+	case OFONO_RADIO_ACCESS_MODE_LTE:
+		pref = PREF_NET_TYPE_LTE_GSM_WCDMA;
+		break;
+	}
+
+	if (pref != PREF_NET_TYPE_GSM_ONLY && multisim_num_slots > 1) {
+		struct qcom_msim_pending_pref_setting *pps =
+			g_try_new0(struct qcom_msim_pending_pref_setting, 1);
+		int i;
+
+		pps->rs = rs;
+		pps->pref = pref;
+		pps->cbd = cbd;
+		pps->pending_gsm_pref_remaining = 0;
+
+		for (i = 0; i < QCOMMSIM_NUM_SLOTS_MAX; i++) {
+			struct radio_data *temp_rd;
+			struct qcom_msim_set_2g_rat *set_2g_rat_data;
+
+			if (multisim_rs[i] == rs || multisim_rs[i] == NULL)
+				continue;
+
+			temp_rd = ofono_radio_settings_get_data(multisim_rs[i]);
+			set_2g_rat_data =
+				g_try_new0(struct qcom_msim_set_2g_rat, 1);
+			set_2g_rat_data->pps = pps;
+			set_2g_rat_data->rs = multisim_rs[i];
+
+			g_ril_request_set_preferred_network_type(temp_rd->ril,
+						PREF_NET_TYPE_GSM_ONLY, &rilp);
+
+			if (g_ril_send(temp_rd->ril,
+					RIL_REQUEST_SET_PREFERRED_NETWORK_TYPE,
+					&rilp, qcom_msim_set_2g_rat_cb,
+					set_2g_rat_data, g_free) == 0) {
+				ofono_error("%s: unable to set rat mode",
+								__func__);
+				pps->cbd = NULL;
+				g_free(cbd);
+				g_free(set_2g_rat_data);
+				CALLBACK_WITH_FAILURE(cb, data);
+				break;
+			} else {
+				pps->pending_gsm_pref_remaining += 1;
+			}
+		}
+
+		if (pps->pending_gsm_pref_remaining == 0)
+			g_free(pps);
+	} else {
+		g_ril_request_set_preferred_network_type(rd->ril, pref, &rilp);
+
+		if (g_ril_send(rd->ril, RIL_REQUEST_SET_PREFERRED_NETWORK_TYPE,
+					&rilp, qcom_msim_set_rat_cb, cbd,
+					g_free) == 0) {
+			ofono_error("%s: unable to set rat mode", __func__);
+			g_free(cbd);
+			CALLBACK_WITH_FAILURE(cb, data);
+		}
+	}
+}
+
+static int qcom_msim_radio_settings_probe(struct ofono_radio_settings *rs,
+					unsigned int vendor, void *user)
+{
+	struct ril_radio_settings_driver_data *rs_init_data = user;
+	struct radio_data *rsd = g_try_new0(struct radio_data, 1);
+	int slot_id;
+
+	if (rsd == NULL) {
+		ofono_error("%s: cannot allocate memory", __func__);
+		return -ENOMEM;
+	}
+
+	rsd->ril = g_ril_clone(rs_init_data->gril);
+	rsd->modem = rs_init_data->modem;
+
+	ofono_radio_settings_set_data(rs, rsd);
+
+	ril_set_fast_dormancy(rs, FALSE, ril_delayed_register, rs);
+
+	slot_id = ofono_modem_get_integer(rsd->modem, "Slot");
+	multisim_rs[slot_id] = rs;
+	multisim_num_slots += 1;
+
+	return 0;
+}
+
+static void qcom_msim_radio_settings_remove(struct ofono_radio_settings *rs)
+{
+	struct radio_data *rd = ofono_radio_settings_get_data(rs);
+	int slot_id = ofono_modem_get_integer(rd->modem, "Slot");
+
+	multisim_rs[slot_id] = NULL;
+	multisim_num_slots -= 1;
+
+	ofono_radio_settings_set_data(rs, NULL);
+
+	g_ril_unref(rd->ril);
+	g_free(rd);
+}
+
+static struct ofono_radio_settings_driver driver = {
+	.name			= QCOMMSIMMODEM,
+	.probe			= qcom_msim_radio_settings_probe,
+	.remove			= qcom_msim_radio_settings_remove,
+	.query_rat_mode		= ril_query_rat_mode,
+	.set_rat_mode		= qcom_msim_set_rat_mode,
+	.query_fast_dormancy	= ril_query_fast_dormancy,
+	.set_fast_dormancy	= ril_set_fast_dormancy,
+	.query_modem_rats	= ril_query_modem_rats
+};
+
+void qcom_msim_radio_settings_init(void)
+{
+	ofono_radio_settings_driver_register(&driver);
+}
+
+void qcom_msim_radio_settings_exit(void)
+{
+	ofono_radio_settings_driver_unregister(&driver);
+}

--- a/drivers/rilmodem/radio-settings.c
+++ b/drivers/rilmodem/radio-settings.c
@@ -229,7 +229,7 @@ static ofono_bool_t query_modem_rats_cb(gpointer user_data)
 	return FALSE;
 }
 
-static void ril_query_modem_rats(struct ofono_radio_settings *rs,
+void ril_query_modem_rats(struct ofono_radio_settings *rs,
 				ofono_radio_settings_modem_rats_query_cb_t cb,
 				void *data)
 {

--- a/drivers/rilmodem/radio-settings.h
+++ b/drivers/rilmodem/radio-settings.h
@@ -42,3 +42,6 @@ void ril_set_fast_dormancy(struct ofono_radio_settings *rs,
 				ofono_bool_t enable,
 				ofono_radio_settings_fast_dormancy_set_cb_t cb,
 				void *data);
+void ril_query_modem_rats(struct ofono_radio_settings *rs,
+				ofono_radio_settings_modem_rats_query_cb_t cb,
+				void *data);

--- a/include/radio-settings.h
+++ b/include/radio-settings.h
@@ -136,6 +136,9 @@ void ofono_radio_settings_remove(struct ofono_radio_settings *rs);
 void ofono_radio_settings_set_data(struct ofono_radio_settings *rs, void *data);
 void *ofono_radio_settings_get_data(struct ofono_radio_settings *rs);
 
+void ofono_radio_settings_set_rat_mode(struct ofono_radio_settings *rs,
+					enum ofono_radio_access_mode mode);
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -63,6 +63,7 @@
 #include "ril.h"
 #include "drivers/rilmodem/rilmodem.h"
 #include "drivers/rilmodem/vendor.h"
+#include "drivers/qcommsimmodem/qcom_msim_modem.h"
 
 #define MAX_SIM_STATUS_RETRIES 15
 
@@ -112,11 +113,19 @@ static void ril_radio_state_changed(struct ril_msg *message, gpointer user_data)
 		case RADIO_STATE_ON:
 
 			if (rd->radio_settings == NULL) {
+				char *rs_driver;
 				struct ril_radio_settings_driver_data rs_data =
 							{ rd->ril, modem };
+
+				if (rd->vendor == OFONO_RIL_VENDOR_QCOM_MSIM)
+					rs_driver = QCOMMSIMMODEM;
+				else
+					rs_driver = RILMODEM;
+
 				rd->radio_settings =
 					ofono_radio_settings_create(modem,
-						rd->vendor, RILMODEM, &rs_data);
+							rd->vendor, rs_driver,
+							&rs_data);
 			}
 
 			break;

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -70,7 +70,8 @@
 #define RILD_MAX_CONNECT_RETRIES 5
 #define RILD_CONNECT_RETRY_TIME_S 5
 
-#define RILD_CMD_SOCKET "/dev/socket/rild"
+char *RILD_CMD_SOCKET[] = {"/dev/socket/rild", "/dev/socket/rild1"};
+char *GRIL_HEX_PREFIX[] = {"Device 0: ", "Device 1: "};
 
 struct ril_data {
 	GRil *ril;
@@ -337,8 +338,11 @@ static void ril_connected(struct ril_msg *message, gpointer user_data)
 static int create_gril(struct ofono_modem *modem)
 {
 	struct ril_data *rd = ofono_modem_get_data(modem);
+	int slot_id = ofono_modem_get_integer(modem, "Slot");
 
-	rd->ril = g_ril_new(RILD_CMD_SOCKET, OFONO_RIL_VENDOR_AOSP);
+	ofono_info("Using %s as socket for slot %d.",
+					RILD_CMD_SOCKET[slot_id], slot_id);
+	rd->ril = g_ril_new(RILD_CMD_SOCKET[slot_id], OFONO_RIL_VENDOR_AOSP);
 
 	/* NOTE: Since AT modems open a tty, and then call
 	 * g_at_chat_new(), they're able to return -EIO if
@@ -352,12 +356,13 @@ static int create_gril(struct ofono_modem *modem)
 		ofono_error("g_ril_new() failed to create modem!");
 		return -EIO;
 	}
+	g_ril_set_slot(rd->ril, slot_id);
 
 	if (getenv("OFONO_RIL_TRACE"))
 		g_ril_set_trace(rd->ril, TRUE);
 
 	if (getenv("OFONO_RIL_HEX_TRACE"))
-		g_ril_set_debugf(rd->ril, ril_debug, "Device: ");
+		g_ril_set_debugf(rd->ril, ril_debug, GRIL_HEX_PREFIX[slot_id]);
 
 	g_ril_register(rd->ril, RIL_UNSOL_RIL_CONNECTED,
 			ril_connected, modem);

--- a/src/radio-settings.c
+++ b/src/radio-settings.c
@@ -338,7 +338,7 @@ static void radio_band_set_callback(const struct ofono_error *error,
 	radio_set_band(rs);
 }
 
-static void radio_set_rat_mode(struct ofono_radio_settings *rs,
+void ofono_radio_settings_set_rat_mode(struct ofono_radio_settings *rs,
 				enum ofono_radio_access_mode mode)
 {
 	DBusConnection *conn = ofono_dbus_get_connection();
@@ -378,7 +378,7 @@ static void radio_mode_set_callback(const struct ofono_error *error, void *data)
 	reply = dbus_message_new_method_return(rs->pending);
 	__ofono_dbus_pending_reply(&rs->pending, reply);
 
-	radio_set_rat_mode(rs, rs->pending_mode);
+	ofono_radio_settings_set_rat_mode(rs, rs->pending_mode);
 }
 
 static void radio_send_properties_reply(struct ofono_radio_settings *rs)
@@ -513,7 +513,7 @@ static void radio_rat_mode_query_callback(const struct ofono_error *error,
 		return;
 	}
 
-	radio_set_rat_mode(rs, mode);
+	ofono_radio_settings_set_rat_mode(rs, mode);
 	radio_query_band(rs);
 }
 


### PR DESCRIPTION
This is improvement of qcom-msim plugin that allow you to use other SIM slot and be able to select which SIM will prefer 3G. This modem has limitation that only 1 SIM can prefer 3G at a time, so the new radio-settings driver will make sure that other SIMs prefer 2G before setting a SIM to prefer 3G. I code this to support more than 2 SIM slots, but there are some constants which assume that only 2 SIM slots are available. If, in the future, there are phones with more than 2 SIM slots, these constants can be edited to support them.