### PR TITLE
test: reverse meaning of list-modems -p

### DIFF
--- a/test/list-modems
+++ b/test/list-modems
@@ -13,10 +13,11 @@ def parse_arguments():
 	parser.add_argument("-p",
 			"--private",
 			dest="priv",
-			help="""Specifies that properties considered private
-			should be output as clear-text vs. obfuscated""",
-			action="store_false",
-			default="true"
+			help="""Specifies that properties considered
+			private	should be output obfuscated vs.
+			cleartext (default).""",
+			action="store_true",
+			default=False
 			)
 
 	return parser.parse_args()


### PR DESCRIPTION
This change inverts the initial implementation of the
privacy flag no longer making it the default behavior.
The original change broke autopkg tests for python-dbusmock,
and also was probably not acceptable to upstream as it
changed the default behavior of the script.