### PR TITLE
Retry when a context deactivation request has finished with an error

### DIFF
--- a/drivers/mtkmodem/mtkutil.h
+++ b/drivers/mtkmodem/mtkutil.h
@@ -35,6 +35,7 @@ void mtk_set_attach_state(struct ofono_modem *modem, ofono_bool_t attached);
 void mtk_detach_received(struct ofono_modem *modem);
 
 void mtk_reset_all_modems(void);
+void mtk_reset_modem(struct ofono_modem *modem);
 
 const char *mtk_request_id_to_string(int req);
 const char *mtk_unsol_request_to_string(int req);

--- a/drivers/rilmodem/rilutil.h
+++ b/drivers/rilmodem/rilutil.h
@@ -75,6 +75,7 @@ struct ril_sim_data {
 
 struct ril_gprs_context_data {
 	GRil *gril;
+	struct ofono_modem *modem;
 	enum ofono_gprs_context_type type;
 };
 

--- a/plugins/mtk.c
+++ b/plugins/mtk.c
@@ -830,9 +830,9 @@ static void sim_state_watch(enum ofono_sim_state new_state, void *data)
 		struct ofono_gprs_context *gc;
 		struct ril_gprs_driver_data gprs_data = { md->ril, modem };
 		struct ril_gprs_context_data inet_ctx =
-			{ md->ril, OFONO_GPRS_CONTEXT_TYPE_INTERNET };
+			{ md->ril, modem, OFONO_GPRS_CONTEXT_TYPE_INTERNET };
 		struct ril_gprs_context_data mms_ctx =
-			{ md->ril, OFONO_GPRS_CONTEXT_TYPE_MMS };
+			{ md->ril, modem, OFONO_GPRS_CONTEXT_TYPE_MMS };
 
 		DBG("SIM ready, creating more atoms");
 
@@ -1345,6 +1345,16 @@ void mtk_reset_all_modems(void)
 		mtk_set_online(mtk_data_0->modem, FALSE, set_offline_cb, NULL);
 	else
 		mtk_set_online(mtk_data_1->modem, FALSE, set_offline_cb, NULL);
+}
+
+void mtk_reset_modem(struct ofono_modem *modem)
+{
+
+	if (ofono_modem_get_powered(modem) == FALSE)
+		return;
+
+	ofono_modem_set_powered(modem, FALSE);
+	g_idle_add(mtk_connected, modem);
 }
 
 static void create_atoms_on_connection(struct ofono_modem *modem)

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -225,9 +225,9 @@ void ril_post_sim(struct ofono_modem *modem)
 	struct ofono_message_waiting *mw;
 	struct ril_gprs_driver_data gprs_data = { rd->ril, modem };
 	struct ril_gprs_context_data inet_ctx =
-			{ rd->ril, OFONO_GPRS_CONTEXT_TYPE_INTERNET };
+			{ rd->ril, modem, OFONO_GPRS_CONTEXT_TYPE_INTERNET };
 	struct ril_gprs_context_data mms_ctx =
-			{ rd->ril, OFONO_GPRS_CONTEXT_TYPE_MMS };
+			{ rd->ril, modem, OFONO_GPRS_CONTEXT_TYPE_MMS };
 
 	/* TODO: this function should setup:
 	 *  - phonebook


### PR DESCRIPTION
Retry when a context deactivation request has finished with an error. We can have these error temporarily for some modems. Solves

https://bugs.launchpad.net/tangxi/+bug/1467191