### PR TITLE
Do not assert when the radio is unavailable

### DIFF
--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -129,8 +129,12 @@ static void ril_radio_state_changed(struct ril_msg *message, gpointer user_data)
 			}
 
 			break;
-
 		case RADIO_STATE_UNAVAILABLE:
+			/*
+			 * This state can be received right before the phone is
+			 * powered off: do nothing.
+			 */
+			break;
 		case RADIO_STATE_OFF:
 
 			/*


### PR DESCRIPTION
Fix for LP #1490991:

https://bugs.launchpad.net/canonical-devices-system-image/+bug/1490991