### PR TITLE
Ignore SMS origin port

### DIFF
--- a/src/sms.c
+++ b/src/sms.c
@@ -1184,6 +1184,7 @@ static void dispatch_app_datagram(struct ofono_sms *sms,
 	ofono_sms_datagram_notify_cb_t notify;
 	struct sms_handler *h;
 	GSList *l;
+	gboolean dispatched = FALSE;
 
 	ts = sms_scts_to_time(scts, &remote);
 	localtime_r(&ts, &local);
@@ -1195,9 +1196,15 @@ static void dispatch_app_datagram(struct ofono_sms *sms,
 		if (!port_equal(dst, h->dst) || !port_equal(src, h->src))
 			continue;
 
+		dispatched = TRUE;
+
 		notify(sender, &remote, &local, dst, src, buf, len,
 			h->item.notify_data);
 	}
+
+	if (!dispatched)
+		ofono_info("Datagram with ports [%d,%d] not delivered",
+								dst, src);
 }
 
 static void dispatch_text_message(struct ofono_sms *sms,

--- a/src/smsutil.c
+++ b/src/smsutil.c
@@ -1935,9 +1935,6 @@ static gboolean extract_app_port_common(struct sms_udh_iter *iter, int *dst,
 			if (((addr_hdr[0] << 8) | addr_hdr[1]) > 49151)
 				break;
 
-			if (((addr_hdr[2] << 8) | addr_hdr[3]) > 49151)
-				break;
-
 			dstport = (addr_hdr[0] << 8) | addr_hdr[1];
 			srcport = (addr_hdr[2] << 8) | addr_hdr[3];
 			is_addr_8bit = FALSE;


### PR DESCRIPTION
Some operators do not set properly the origin port in the SMS header when sending a push notification, so we check only the destination port. Fixes

https://bugs.launchpad.net/ubuntu/+source/nuntium/+bug/1490673