### PR TITLE
Revert "ril: Do not assert when the radio is unavailable"

### DIFF
--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -129,12 +129,8 @@ static void ril_radio_state_changed(struct ril_msg *message, gpointer user_data)
 			}
 
 			break;
+
 		case RADIO_STATE_UNAVAILABLE:
-			/*
-			 * This state can be received right before the phone is
-			 * powered off: do nothing.
-			 */
-			break;
 		case RADIO_STATE_OFF:
 
 			/*


### PR DESCRIPTION
Revert this commit to land 1.16 first.
This reverts commit e5242a80c878452fec83d654cbf410aeb93f48cd.