### PR TITLE
Improve HFP AG support for BlueZ 5.x

### DIFF
--- a/doc/handsfree-audio-api.txt
+++ b/doc/handsfree-audio-api.txt
@@ -89,6 +89,10 @@ Properties	string RemoteAddress [readonly]
 
 			Bluetooth address of the local adapter.
 
+		string Type [readonly]
+
+			Type of the card. Valid values are "gateway" or
+			"handsfree".
 
 Handsfree Audio Agent hierarchy [experimental]
 ===============================

--- a/include/emulator.h
+++ b/include/emulator.h
@@ -50,6 +50,7 @@ extern "C" {
 
 struct ofono_emulator;
 struct ofono_emulator_request;
+struct ofono_handsfree_card;
 
 enum ofono_emulator_type {
 	OFONO_EMULATOR_TYPE_DUN,
@@ -107,6 +108,9 @@ void ofono_emulator_set_indicator(struct ofono_emulator *em,
 void ofono_emulator_set_hf_indicator_active(struct ofono_emulator *em,
 						int indicator,
 						ofono_bool_t active);
+
+void ofono_emulator_set_handsfree_card(struct ofono_emulator *em,
+					struct ofono_handsfree_card *card);
 
 #ifdef __cplusplus
 }

--- a/include/handsfree-audio.h
+++ b/include/handsfree-audio.h
@@ -30,6 +30,11 @@ extern "C" {
 
 struct ofono_handsfree_card;
 
+enum ofono_handsfree_card_type {
+	OFONO_HANDSFREE_CARD_TYPE_HANDSFREE,
+	OFONO_HANDSFREE_CARD_TYPE_GATEWAY,
+};
+
 typedef void (*ofono_handsfree_card_connect_cb_t)(
 				const struct ofono_error *error, void *data);
 
@@ -45,8 +50,9 @@ struct ofono_handsfree_card_driver {
 };
 
 struct ofono_handsfree_card *ofono_handsfree_card_create(unsigned int vendor,
-							const char *driver,
-							void *data);
+				enum ofono_handsfree_card_type type,
+				const char *driver,
+				void *data);
 int ofono_handsfree_card_register(struct ofono_handsfree_card *card);
 void ofono_handsfree_card_remove(struct ofono_handsfree_card *card);
 ofono_bool_t ofono_handsfree_card_set_codec(struct ofono_handsfree_card *card,

--- a/plugins/hfp_hf_bluez5.c
+++ b/plugins/hfp_hf_bluez5.c
@@ -589,7 +589,9 @@ static DBusMessage *profile_new_connection(DBusConnection *conn,
 	if (version >= HFP_VERSION_1_6)
 		driver = HFP16_HF_DRIVER;
 
-	hfp->card = ofono_handsfree_card_create(0, driver, hfp);
+	hfp->card = ofono_handsfree_card_create(0,
+					OFONO_HANDSFREE_CARD_TYPE_HANDSFREE,
+					driver, hfp);
 	ofono_handsfree_card_set_data(hfp->card, hfp);
 
 	ofono_handsfree_card_set_local(hfp->card, local);

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -35,6 +35,7 @@
 #include "hfp.h"
 #include "gatserver.h"
 #include "gatppp.h"
+#include "handsfree-audio.h"
 
 #define RING_TIMEOUT 3
 

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -48,6 +48,7 @@ struct ofono_emulator {
 	GSList *indicators;
 	guint callsetup_source;
 	int pns_id;
+	struct ofono_handsfree_card *card;
 	bool slc : 1;
 	unsigned int events_mode : 2;
 	bool events_ind : 1;
@@ -990,6 +991,9 @@ static void emulator_unregister(struct ofono_atom *atom)
 
 	g_at_server_unref(em->server);
 	em->server = NULL;
+
+	ofono_handsfree_card_remove(em->card);
+	em->card = NULL;
 }
 
 void ofono_emulator_register(struct ofono_emulator *em, int fd)
@@ -1435,6 +1439,8 @@ void __ofono_emulator_slc_condition(struct ofono_emulator *em,
 		ofono_info("SLC reached");
 		em->slc = TRUE;
 
+		ofono_handsfree_card_register(em->card);
+
 	default:
 		break;
 	}
@@ -1459,4 +1465,13 @@ void ofono_emulator_set_hf_indicator_active(struct ofono_emulator *em,
 
 	sprintf(buf, "+BIND: %d,%d", HFP_HF_INDICATOR_ENHANCED_SAFETY, active);
 	g_at_server_send_unsolicited(em->server, buf);
+}
+
+void ofono_emulator_set_handsfree_card(struct ofono_emulator *em,
+					struct ofono_handsfree_card *card)
+{
+	if (em == NULL)
+		return;
+
+	em->card = card;
 }


### PR DESCRIPTION
Until now the BlueZ 5 plugin for HFP AG support didn't registered a handsfree audio card which is necessary to get others (PulseAudio) be notified that we're connected with a HFP HF device. In former times with BlueZ 4 this wasn't necessary as the profile management was done differently. Nowadays with BlueZ 5 ofono has the main control over the HFP profile connection endpoint and we have to share a SCO connection with the actual user (PulseAudio) through the org.ofono.HandsfreeAudio management interface.

PulseAudio will register a org.ofono.HandsfreeAudioAgent with us to get notified when a connection is setup and will call org.ofono.HandsfreeAudioCard.Connect when needed.