### PR TITLE
New rilmodem sms tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ unit/test-mnclength
 unit/test-mtkreply
 unit/test-mtkrequest
 unit/test-mtkunsol
+unit/test-rilmodem-cs
+unit/test-rilmodem-sms
 unit/test-*.log
 unit/test-*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -905,23 +905,24 @@ unit_test_mnclength_SOURCES = unit/test-mnclength.c plugins/mnclength.c \
 unit_test_mnclength_LDADD = @GLIB_LIBS@ -ldl
 unit_objects += $(unit_test_mnclength_OBJECTS)
 
-unit_test_rilmodem_cs_SOURCES = unit/test-rilmodem-cs.c $(gril_sources) \
-			src/log.c src/common.c src/util.c \
-			drivers/rilmodem/call-settings.c \
-			src/simutil.c gatchat/ringbuffer.c
+test_rilmodem_sources = $(gril_sources) src/log.c src/common.c src/util.c \
+				gatchat/ringbuffer.h gatchat/ringbuffer.c \
+				unit/rilmodem-test-server.h \
+				unit/rilmodem-test-server.c \
+				src/simutil.c
+
+unit_test_rilmodem_cs_SOURCES = $(test_rilmodem_sources) \
+					unit/test-rilmodem-cs.c \
+					drivers/rilmodem/call-settings.c
 unit_test_rilmodem_cs_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
-			@GLIB_LIBS@ @DBUS_LIBS@ -ldl
+					@GLIB_LIBS@ @DBUS_LIBS@ -ldl
 unit_objects += $(unit_test_rilmodem_cs_OBJECTS)
 
-unit_test_rilmodem_sms_SOURCES = unit/test-rilmodem-sms.c $(gril_sources) \
-			src/log.c src/common.c src/util.c \
-			gatchat/ringbuffer.h gatchat/ringbuffer.c \
-			drivers/rilmodem/sms.c \
-			unit/rilmodem-test-server.h \
-			unit/rilmodem-test-server.c \
-			src/simutil.c
+unit_test_rilmodem_sms_SOURCES = $(test_rilmodem_sources) \
+					unit/test-rilmodem-sms.c \
+					drivers/rilmodem/sms.c
 unit_test_rilmodem_sms_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
-			@GLIB_LIBS@ @DBUS_LIBS@ -ldl
+					@GLIB_LIBS@ @DBUS_LIBS@ -ldl
 unit_objects += $(unit_test_rilmodem_sms_OBJECTS)
 
 TESTS = $(unit_tests)

--- a/Makefile.am
+++ b/Makefile.am
@@ -808,7 +808,8 @@ unit_tests = unit/test-common unit/test-util unit/test-idmap \
 				unit/test-mtkrequest \
 				unit/test-mtkreply \
 				unit/test-mtkunsol \
-				unit/test-rilmodem-cs
+				unit/test-rilmodem-cs \
+				unit/test-rilmodem-sms
 
 noinst_PROGRAMS = $(unit_tests) \
 			unit/test-sms-root unit/test-mux unit/test-caif
@@ -911,6 +912,17 @@ unit_test_rilmodem_cs_SOURCES = unit/test-rilmodem-cs.c $(gril_sources) \
 unit_test_rilmodem_cs_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
 			@GLIB_LIBS@ @DBUS_LIBS@ -ldl
 unit_objects += $(unit_test_rilmodem_cs_OBJECTS)
+
+unit_test_rilmodem_sms_SOURCES = unit/test-rilmodem-sms.c $(gril_sources) \
+			src/log.c src/common.c src/util.c \
+			gatchat/ringbuffer.h gatchat/ringbuffer.c \
+			drivers/rilmodem/sms.c \
+			unit/rilmodem-test-server.h \
+			unit/rilmodem-test-server.c \
+			src/simutil.c
+unit_test_rilmodem_sms_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
+			@GLIB_LIBS@ @DBUS_LIBS@ -ldl
+unit_objects += $(unit_test_rilmodem_sms_OBJECTS)
 
 TESTS = $(unit_tests)
 

--- a/drivers/rilmodem/sms.c
+++ b/drivers/rilmodem/sms.c
@@ -127,19 +127,17 @@ static void ril_csca_query(struct ofono_sms *sms, ofono_sms_sca_query_cb_t cb,
 static void ril_submit_sms_cb(struct ril_msg *message, gpointer user_data)
 {
 	struct cb_data *cbd = user_data;
-	struct ofono_error error;
 	ofono_sms_submit_cb_t cb = cbd->cb;
 	struct sms_data *sd = cbd->user;
-	int mr = 0;
+	int mr;
 
-	if (message->error == RIL_E_SUCCESS) {
-		decode_ril_error(&error, "OK");
-		mr = g_ril_reply_parse_sms_response(sd->ril, message);
-	} else {
-		decode_ril_error(&error, "FAIL");
+	if (message->error != RIL_E_SUCCESS) {
+		CALLBACK_WITH_FAILURE(cb, 0, cbd->data);
+		return;
 	}
 
-	cb(&error, mr, cbd->data);
+	mr = g_ril_reply_parse_sms_response(sd->ril, message);
+	CALLBACK_WITH_SUCCESS(cb, mr, cbd->data);
 }
 
 static void ril_cmgs(struct ofono_sms *sms, const unsigned char *pdu,

--- a/unit/rilmodem-test-server.c
+++ b/unit/rilmodem-test-server.c
@@ -1,0 +1,196 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2015 Canonical Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <ofono/types.h>
+
+#include <gril.h>
+
+#include "rilmodem-test-server.h"
+
+#define MAX_REQUEST_SIZE 4096
+
+static int server_sk;
+static ConnectFunc connect_func;
+static GIOChannel *server_io;
+static const struct rilmodem_test_data *rtd;
+
+/* Warning: length is stored in network order */
+struct rsp_hdr {
+	uint32_t length;
+	uint32_t unsolicited;
+	uint32_t serial;
+	uint32_t error;
+};
+
+static gboolean read_server(gpointer data)
+{
+	GIOStatus status;
+	gsize offset, rbytes, wbytes;
+	gchar *buf, *bufp;
+	uint32_t req_serial;
+	struct rsp_hdr rsp;
+
+	buf = g_malloc0(MAX_REQUEST_SIZE);
+
+	status = g_io_channel_read_chars(server_io, buf, MAX_REQUEST_SIZE,
+								&rbytes, NULL);
+	g_assert(status == G_IO_STATUS_NORMAL);
+
+	g_assert(rbytes == rtd->req_size);
+
+	/* validate len, and request_id */
+	g_assert(!memcmp(buf, rtd->req_data, (sizeof(uint32_t) * 2)));
+
+	/*
+	 * header: size (uint32), reqid (uin32), serial (uint32)
+	 * header size == 16 ( excludes sizeof(size) )
+	 */
+
+	/* advance past request_no */
+	bufp = buf + (sizeof(uint32_t) * 2);
+
+	req_serial = (uint32_t) *bufp;
+
+	/* advance past serial_no */
+	bufp += sizeof(uint32_t);
+
+	/* validate the rest of the parcel... */
+	offset = (sizeof(uint32_t) * 3);
+	g_assert(!memcmp(bufp, rtd->req_data + offset,
+						rtd->req_size - offset));
+
+	/* Length does not include the length field. Network order. */
+	rsp.length = htonl(sizeof(rsp) - sizeof(rsp.length) + rtd->rsp_size);
+	rsp.unsolicited = 0;
+	rsp.serial = req_serial;
+	rsp.error = rtd->rsp_error;
+
+	/* copy header */
+	memcpy(buf, &rsp, sizeof(rsp));
+
+	if (rtd->rsp_size) {
+		bufp = buf + sizeof(rsp);
+
+		memcpy(bufp, rtd->rsp_data, rtd->rsp_size);
+	}
+
+
+	status = g_io_channel_write_chars(server_io,
+					buf,
+					sizeof(rsp) + rtd->rsp_size,
+					&wbytes, NULL);
+
+	/* FIXME: assert wbytes is correct */
+
+	g_assert(status == G_IO_STATUS_NORMAL);
+
+	g_free(buf);
+	g_io_channel_unref(server_io);
+
+	return FALSE;
+}
+
+static gboolean on_socket_connected(GIOChannel *chan, GIOCondition cond,
+								gpointer data)
+{
+	struct sockaddr saddr;
+	unsigned int len = sizeof(saddr);
+	int fd;
+	GIOStatus status;
+
+	g_assert(cond == G_IO_IN);
+
+	fd = accept(server_sk, &saddr, &len);
+	g_assert(fd != -1);
+
+	server_io = g_io_channel_unix_new(fd);
+	g_assert(server_io != NULL);
+
+	if (connect_func)
+		connect_func(data);
+
+	status = g_io_channel_set_encoding(server_io, NULL, NULL);
+	g_assert(status == G_IO_STATUS_NORMAL);
+
+	g_io_channel_set_buffered(server_io, FALSE);
+	g_io_channel_set_close_on_unref(server_io, TRUE);
+
+	g_idle_add(read_server, data);
+
+	return FALSE;
+}
+
+void rilmodem_test_server_close(void)
+{
+	g_assert(server_sk);
+	close(server_sk);
+	server_sk = 0;
+}
+
+void rilmodem_test_server_create(ConnectFunc connect,
+				const struct rilmodem_test_data *test_data,
+				void *data)
+{
+	GIOChannel *io;
+	struct sockaddr_un addr;
+	int retval;
+
+	g_assert(server_sk == 0);
+
+	connect_func = connect;
+	rtd = test_data;
+
+	server_sk = socket(AF_UNIX, SOCK_STREAM, 0);
+	g_assert(server_sk);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, RIL_SERVER_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	/* Unlink any existing socket for this session */
+	unlink(addr.sun_path);
+
+	retval = bind(server_sk, (struct sockaddr *) &addr, sizeof(addr));
+	g_assert(retval >= 0);
+
+	retval = listen(server_sk, 0);
+	g_assert(retval >= 0);
+
+	io = g_io_channel_unix_new(server_sk);
+	g_assert(io != NULL);
+
+	g_io_channel_set_close_on_unref(io, TRUE);
+	g_io_add_watch_full(io,	G_PRIORITY_DEFAULT,
+				G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL,
+				on_socket_connected, data, NULL);
+
+	g_io_channel_unref(io);
+}

--- a/unit/rilmodem-test-server.h
+++ b/unit/rilmodem-test-server.h
@@ -21,6 +21,8 @@
 
 #define RIL_SERVER_SOCK_PATH    "/tmp/unittestril"
 
+struct server_data;
+
 struct rilmodem_test_data {
 	const unsigned char *req_data;
 
@@ -29,12 +31,17 @@ struct rilmodem_test_data {
 	uint32_t rsp_error;
 	const unsigned char *rsp_data;
 	const size_t rsp_size;
+	gboolean unsol_test;
 };
 
 typedef void (*ConnectFunc)(void *data);
 
-void rilmodem_test_server_close(void);
+void rilmodem_test_server_close(struct server_data *sd);
 
-void rilmodem_test_server_create(ConnectFunc connect,
+struct server_data *rilmodem_test_server_create(ConnectFunc connect,
 				const struct rilmodem_test_data *test_data,
 				void *data);
+
+void rilmodem_test_server_write(struct server_data *sd,
+						const unsigned char *buf,
+						const size_t buf_len);

--- a/unit/rilmodem-test-server.h
+++ b/unit/rilmodem-test-server.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2015 Canonical Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#define RIL_SERVER_SOCK_PATH    "/tmp/unittestril"
+
+struct rilmodem_test_data {
+	const unsigned char *req_data;
+
+	const size_t req_size;
+
+	uint32_t rsp_error;
+	const unsigned char *rsp_data;
+	const size_t rsp_size;
+};
+
+typedef void (*ConnectFunc)(void *data);
+
+void rilmodem_test_server_close(void);
+
+void rilmodem_test_server_create(ConnectFunc connect,
+				const struct rilmodem_test_data *test_data,
+				void *data);

--- a/unit/test-rilmodem-cs.c
+++ b/unit/test-rilmodem-cs.c
@@ -51,6 +51,7 @@ struct rilmodem_cs_data {
 	struct ofono_modem *modem;
 	gconstpointer test_data;
 	struct ofono_call_settings *cs;
+	struct server_data *serverd;
 };
 
 typedef gboolean (*StartFunc)(gpointer data);
@@ -476,7 +477,8 @@ static void test_cs_func(gconstpointer data)
 
 	rcd->test_data = csd;
 
-	rilmodem_test_server_create(&server_connect_cb, &csd->rtd, rcd);
+	rcd->serverd = rilmodem_test_server_create(&server_connect_cb,
+							&csd->rtd, rcd);
 
 	rcd->ril = g_ril_new("/tmp/unittestril", OFONO_RIL_VENDOR_AOSP);
 	g_assert(rcd->ril != NULL);
@@ -490,7 +492,7 @@ static void test_cs_func(gconstpointer data)
 	g_ril_unref(rcd->ril);
 	g_free(rcd);
 
-	rilmodem_test_server_close();
+	rilmodem_test_server_close(rcd->serverd);
 
 	ril_call_settings_exit();
 }

--- a/unit/test-rilmodem-cs.c
+++ b/unit/test-rilmodem-cs.c
@@ -40,29 +40,17 @@
 
 #include "common.h"
 #include "ril_constants.h"
-
-#define MAX_REQUEST_SIZE 4096
+#include "rilmodem-test-server.h"
 
 static GMainLoop *mainloop;
 
 static const struct ofono_call_settings_driver *csdriver;
 
-struct rilmodemcs_data {
+struct rilmodem_cs_data {
 	GRil *ril;
-	int sk;
-	gint server_watch;
-	GIOChannel *server_io;
 	struct ofono_modem *modem;
 	gconstpointer test_data;
 	struct ofono_call_settings *cs;
-};
-
-/* Warning: length is stored in network order */
-struct rsp_hdr {
-	uint32_t length;
-	uint32_t unsolicited;
-	uint32_t serial;
-	uint32_t error;
 };
 
 typedef gboolean (*StartFunc)(gpointer data);
@@ -72,13 +60,7 @@ struct cs_data {
 	gint param_int1;
 	gint param_int2;
 
-	const guchar *parcel_data;
-
-	const gsize parcel_size;
-
-	uint32_t rsp_error;
-	const guchar *rsp_data;
-	const gsize rsp_size;
+	struct rilmodem_test_data rtd;
 	enum ofono_error_type error_type;
 	gint cb_int1;
 	gint cb_int2;
@@ -87,8 +69,8 @@ struct cs_data {
 static void status_query_callback(const struct ofono_error *error, int status,
 								 gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
 
 	g_assert(error->type == csd->error_type);
 
@@ -101,8 +83,8 @@ static void status_query_callback(const struct ofono_error *error, int status,
 static void clir_query_callback(const struct ofono_error *error, int override,
 						int network, gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
 
 	g_assert(error->type == csd->error_type);
 
@@ -116,8 +98,8 @@ static void clir_query_callback(const struct ofono_error *error, int override,
 
 static void set_callback(const struct ofono_error *error, gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
 
 	g_assert(error->type == csd->error_type);
 
@@ -126,56 +108,56 @@ static void set_callback(const struct ofono_error *error, gpointer data)
 
 static gboolean trigger_clip_query(gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
+	struct rilmodem_cs_data *rcd = data;
 
 	g_assert(csdriver->clip_query != NULL);
-	csdriver->clip_query(rcsd->cs, status_query_callback, rcsd);
+	csdriver->clip_query(rcd->cs, status_query_callback, rcd);
 
 	return FALSE;
 }
 
 static gboolean trigger_cw_query(gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
+	struct rilmodem_cs_data *rcd = data;
 
 	g_assert(csdriver->cw_query != NULL);
 
 	/* cls is explicitly ignored by rilmodem; just use 0 */
-	csdriver->cw_query(rcsd->cs, 0, status_query_callback, rcsd);
+	csdriver->cw_query(rcd->cs, 0, status_query_callback, rcd);
 
 	return FALSE;
 }
 
 static gboolean trigger_cw_set(gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
 
 	g_assert(csdriver->cw_set != NULL);
 
-	csdriver->cw_set(rcsd->cs, csd->param_int1, csd->param_int2,
-						set_callback, rcsd);
+	csdriver->cw_set(rcd->cs, csd->param_int1, csd->param_int2,
+						set_callback, rcd);
 
 	return FALSE;
 }
 
 static gboolean trigger_clir_query(gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
+	struct rilmodem_cs_data *rcd = data;
 
 	g_assert(csdriver->clir_query != NULL);
-	csdriver->clir_query(rcsd->cs, clir_query_callback, rcsd);
+	csdriver->clir_query(rcd->cs, clir_query_callback, rcd);
 
 	return FALSE;
 }
 
 static gboolean trigger_clir_set(gpointer data)
 {
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
 
 	g_assert(csdriver->clir_set != NULL);
-	csdriver->clir_set(rcsd->cs, csd->param_int1, set_callback, rcsd);
+	csdriver->clir_set(rcd->cs, csd->param_int1, set_callback, rcd);
 
 	return FALSE;
 }
@@ -192,11 +174,13 @@ static const guchar rsp_clip_query_data_1[] = {
 
 static const struct cs_data testdata_clip_query_valid_1 = {
 	.start_func = trigger_clip_query,
-	.parcel_data = req_clip_query_parcel_1,
-	.parcel_size = sizeof(req_clip_query_parcel_1),
-	.rsp_data = rsp_clip_query_data_1,
-	.rsp_size = sizeof(rsp_clip_query_data_1),
-	.rsp_error = RIL_E_SUCCESS,
+	.rtd = {
+		.req_data = req_clip_query_parcel_1,
+		.req_size = sizeof(req_clip_query_parcel_1),
+		.rsp_data = rsp_clip_query_data_1,
+		.rsp_size = sizeof(rsp_clip_query_data_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.cb_int1 = 1,
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
@@ -209,21 +193,25 @@ static const guchar rsp_clip_query_data_2[] = {
 /* reply parse error causes status to be returned as -1 */
 static const struct cs_data testdata_clip_query_invalid_1 = {
 	.start_func = trigger_clip_query,
-	.parcel_data = req_clip_query_parcel_1,
-	.parcel_size = sizeof(req_clip_query_parcel_1),
-	.rsp_data = rsp_clip_query_data_2,
-	.rsp_size = sizeof(rsp_clip_query_data_2),
+	.rtd = {
+		.req_data = req_clip_query_parcel_1,
+		.req_size = sizeof(req_clip_query_parcel_1),
+		.rsp_data = rsp_clip_query_data_2,
+		.rsp_size = sizeof(rsp_clip_query_data_2),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.cb_int1 = -1,
-	.rsp_error = RIL_E_SUCCESS,
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
 
 /* error triggered by RIL reply error */
 static const struct cs_data testdata_clip_query_invalid_2 = {
 	.start_func = trigger_clip_query,
-	.parcel_data = req_clip_query_parcel_1,
-	.parcel_size = sizeof(req_clip_query_parcel_1),
-	.rsp_error = RIL_E_GENERIC_FAILURE,
+	.rtd = {
+		.req_data = req_clip_query_parcel_1,
+		.req_size = sizeof(req_clip_query_parcel_1),
+		.rsp_error = RIL_E_GENERIC_FAILURE,
+	},
 	.error_type = OFONO_ERROR_TYPE_FAILURE,
 };
 
@@ -240,11 +228,13 @@ static const guchar rsp_cw_query_data_1[] = {
 
 static const struct cs_data testdata_cw_query_valid_1 = {
 	.start_func = trigger_cw_query,
-	.parcel_data = req_cw_query_parcel_1,
-	.parcel_size = sizeof(req_cw_query_parcel_1),
-	.rsp_data = rsp_cw_query_data_1,
-	.rsp_size = sizeof(rsp_cw_query_data_1),
-	.rsp_error = RIL_E_SUCCESS,
+	.rtd = {
+		.req_data = req_cw_query_parcel_1,
+		.req_size = sizeof(req_cw_query_parcel_1),
+		.rsp_data = rsp_cw_query_data_1,
+		.rsp_size = sizeof(rsp_cw_query_data_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.cb_int1 = 3,
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
@@ -257,24 +247,28 @@ static const guchar rsp_cw_query_data_2[] = {
 /* reply parse error causes status to be returned as -1 */
 static const struct cs_data testdata_cw_query_invalid_1 = {
 	.start_func = trigger_cw_query,
-	.parcel_data = req_cw_query_parcel_1,
-	.parcel_size = sizeof(req_cw_query_parcel_1),
-	.rsp_data = rsp_cw_query_data_2,
-	.rsp_size = sizeof(rsp_cw_query_data_2),
+	.rtd = {
+		.req_data = req_cw_query_parcel_1,
+		.req_size = sizeof(req_cw_query_parcel_1),
+		.rsp_data = rsp_cw_query_data_2,
+		.rsp_size = sizeof(rsp_cw_query_data_2),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.cb_int1 = -1,
-	.rsp_error = RIL_E_SUCCESS,
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
 
 /* GENERIC_FAILURE returned in RIL reply */
 static const struct cs_data testdata_cw_query_invalid_2 = {
 	.start_func = trigger_cw_query,
-	.parcel_data = req_cw_query_parcel_1,
-	.parcel_size = sizeof(req_cw_query_parcel_1),
-	.rsp_data = rsp_cw_query_data_2,
-	.rsp_size = sizeof(rsp_cw_query_data_2),
+	.rtd = {
+		.req_data = req_cw_query_parcel_1,
+		.req_size = sizeof(req_cw_query_parcel_1),
+		.rsp_data = rsp_cw_query_data_2,
+		.rsp_size = sizeof(rsp_cw_query_data_2),
+		.rsp_error = RIL_E_GENERIC_FAILURE,
+	},
 	.cb_int1 = -1,
-	.rsp_error = RIL_E_GENERIC_FAILURE,
 	.error_type = OFONO_ERROR_TYPE_FAILURE,
 };
 
@@ -289,9 +283,11 @@ static const struct cs_data testdata_cw_set_valid_1 = {
 	.start_func = trigger_cw_set,
 	.param_int1 = 1,
 	.param_int2 = BEARER_CLASS_DEFAULT,
-	.parcel_data = req_cw_set_enabled_parcel_1,
-	.parcel_size = sizeof(req_cw_set_enabled_parcel_1),
-	.rsp_error = RIL_E_SUCCESS,
+	.rtd = {
+		.req_data = req_cw_set_enabled_parcel_1,
+		.req_size = sizeof(req_cw_set_enabled_parcel_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
 
@@ -306,9 +302,11 @@ static const struct cs_data testdata_cw_set_invalid_1 = {
 	.start_func = trigger_cw_set,
 	.param_int1 = 0,
 	.param_int2 = 0,
-	.parcel_data = req_cw_set_disabled_parcel_2,
-	.parcel_size = sizeof(req_cw_set_disabled_parcel_2),
-	.rsp_error = RIL_E_GENERIC_FAILURE,
+	.rtd = {
+		.req_data = req_cw_set_disabled_parcel_2,
+		.req_size = sizeof(req_cw_set_disabled_parcel_2),
+		.rsp_error = RIL_E_GENERIC_FAILURE,
+	},
 	.error_type = OFONO_ERROR_TYPE_FAILURE,
 };
 
@@ -324,13 +322,15 @@ static const guchar rsp_clir_query_data_1[] = {
 
 static const struct cs_data testdata_clir_query_valid_1 = {
 	.start_func = trigger_clir_query,
-	.parcel_data = req_clir_query_parcel_1,
-	.parcel_size = sizeof(req_clir_query_parcel_1),
-	.rsp_data = rsp_clir_query_data_1,
-	.rsp_size = sizeof(rsp_clir_query_data_1),
+	.rtd = {
+		.req_data = req_clir_query_parcel_1,
+		.req_size = sizeof(req_clir_query_parcel_1),
+		.rsp_data = rsp_clir_query_data_1,
+		.rsp_size = sizeof(rsp_clir_query_data_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.cb_int1 = 2,
 	.cb_int2 = 4,
-	.rsp_error = RIL_E_SUCCESS,
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
 
@@ -340,11 +340,13 @@ static const guchar rsp_clir_query_data_2[] = {
 };
 static const struct cs_data testdata_clir_query_invalid_1 = {
 	.start_func = trigger_clir_query,
-	.parcel_data = req_clir_query_parcel_1,
-	.parcel_size = sizeof(req_clir_query_parcel_1),
-	.rsp_data = rsp_clir_query_data_2,
-	.rsp_size = sizeof(rsp_clir_query_data_2),
-	.rsp_error = RIL_E_SUCCESS,
+	.rtd = {
+		.req_data = req_clir_query_parcel_1,
+		.req_size = sizeof(req_clir_query_parcel_1),
+		.rsp_data = rsp_clir_query_data_2,
+		.rsp_size = sizeof(rsp_clir_query_data_2),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.error_type = OFONO_ERROR_TYPE_FAILURE,
 };
 
@@ -357,9 +359,11 @@ static const guchar req_clir_set_mode0_parcel_1[] = {
 static const struct cs_data testdata_clir_set_valid_1 = {
 	.start_func = trigger_clir_set,
 	.param_int1 = OFONO_CLIR_OPTION_DEFAULT,
-	.parcel_data = req_clir_set_mode0_parcel_1,
-	.parcel_size = sizeof(req_clir_set_mode0_parcel_1),
-	.rsp_error = RIL_E_SUCCESS,
+	.rtd = {
+		.req_data = req_clir_set_mode0_parcel_1,
+		.req_size = sizeof(req_clir_set_mode0_parcel_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
 	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
 };
 
@@ -373,9 +377,12 @@ static const guchar req_clir_set_mode0_parcel_2[] = {
 static const struct cs_data testdata_clir_set_invalid_1 = {
 	.start_func = trigger_clir_set,
 	.param_int1 = OFONO_CLIR_OPTION_INVOCATION,
-	.parcel_data = req_clir_set_mode0_parcel_2,
-	.parcel_size = sizeof(req_clir_set_mode0_parcel_2),
-	.rsp_error = RIL_E_GENERIC_FAILURE,
+
+	.rtd = {
+		.req_data = req_clir_set_mode0_parcel_2,
+		.req_size = sizeof(req_clir_set_mode0_parcel_2),
+		.rsp_error = RIL_E_GENERIC_FAILURE,
+	},
 	.error_type = OFONO_ERROR_TYPE_FAILURE,
 };
 
@@ -392,11 +399,11 @@ struct ofono_call_settings *ofono_call_settings_create(struct ofono_modem *modem
 							const char *driver,
 							void *data)
 {
-	struct rilmodemcs_data *rcsd = data;
+	struct rilmodem_cs_data *rcd = data;
 	struct ofono_call_settings *cs = g_new0(struct ofono_call_settings, 1);
 	int retval;
 
-	retval = csdriver->probe(cs, OFONO_RIL_VENDOR_AOSP, rcsd->ril);
+	retval = csdriver->probe(cs, OFONO_RIL_VENDOR_AOSP, rcd->ril);
 	g_assert(retval == 0);
 
 	return cs;
@@ -422,12 +429,23 @@ void *ofono_call_settings_get_data(struct ofono_call_settings *cs)
 
 void ofono_call_settings_register(struct ofono_call_settings *cs)
 {
-	;
 }
 
 void ofono_call_settings_driver_unregister(const struct ofono_call_settings_driver *d)
 {
-	;
+}
+
+static void server_connect_cb(gpointer data)
+{
+	struct rilmodem_cs_data *rcd = data;
+	const struct cs_data *csd = rcd->test_data;
+
+	/* This causes local impl of _create() to call driver's probe func. */
+	rcd->cs = ofono_call_settings_create(NULL, OFONO_RIL_VENDOR_AOSP,
+							"rilmodem", rcd);
+
+	/* add_idle doesn't work, read blocks main loop!!! */
+	g_assert(csd->start_func(rcd) == FALSE);
 }
 
 /*
@@ -438,163 +456,10 @@ void ofono_call_settings_driver_unregister(const struct ofono_call_settings_driv
  */
 #if BYTE_ORDER == LITTLE_ENDIAN
 
-static gboolean read_server(gpointer data)
-{
-	GIOStatus status;
-	struct rilmodemcs_data *rcsd = data;
-	gsize offset, rbytes, wbytes;
-	gchar *buf, *bufp;
-	uint32_t req_serial;
-	struct rsp_hdr rsp;
-
-	/*
-	 * FIXME: separate out verification from here, so read_server doesn't
-	 * need to know about cs_data.
-	 */
-	const struct cs_data *csd = rcsd->test_data;
-
-	buf = g_malloc0(MAX_REQUEST_SIZE);
-
-	status = g_io_channel_read_chars(rcsd->server_io, buf, MAX_REQUEST_SIZE,
-								&rbytes, NULL);
-	g_assert(status == G_IO_STATUS_NORMAL);
-	g_assert(rbytes == csd->parcel_size);
-
-	/* validate len, and request_id */
-	g_assert(!memcmp(buf, csd->parcel_data, (sizeof(uint32_t) * 2)));
-
-	/*
-	 * header: size (uint32), reqid (uin32), serial (uint32)
-	 * header size == 16 ( excludes sizeof(size) )
-	 */
-
-	/* advance past request_no */
-	bufp = buf + (sizeof(uint32_t) * 2);
-
-	req_serial = (uint32_t) *bufp;
-
-	/* advance past serial_no */
-	bufp += sizeof(uint32_t);
-
-	/* validate the rest of the parcel... */
-	offset = (sizeof(uint32_t) * 3);
-	g_assert(!memcmp(bufp, csd->parcel_data + offset,
-						csd->parcel_size - offset));
-
-	/* Length does not include the length field. Network order. */
-	rsp.length = htonl(sizeof(rsp) - sizeof(rsp.length) + csd->rsp_size);
-	rsp.unsolicited = 0;
-	rsp.serial = req_serial;
-	rsp.error = csd->rsp_error;
-
-	/* copy header */
-	memcpy(buf, &rsp, sizeof(rsp));
-
-	if (csd->rsp_size) {
-		bufp = buf + sizeof(rsp);
-
-		memcpy(bufp, csd->rsp_data, csd->rsp_size);
-	}
-
-
-	status = g_io_channel_write_chars(rcsd->server_io,
-					buf,
-					sizeof(rsp) + csd->rsp_size,
-					&wbytes, NULL);
-
-	/* FIXME: assert wbytes is correct */
-
-	g_assert(status == G_IO_STATUS_NORMAL);
-
-	g_free(buf);
-	g_io_channel_unref(rcsd->server_io);
-
-	return FALSE;
-}
-
-static gboolean on_socket_connected(GIOChannel *chan, GIOCondition cond,
-								gpointer data)
-{
-	struct rilmodemcs_data *rcsd = data;
-	const struct cs_data *csd = rcsd->test_data;
-	struct sockaddr saddr;
-	unsigned int len = sizeof(saddr);
-	int fd;
-	GIOChannel *server_io = NULL;
-	GIOStatus status;
-
-	g_assert(cond == G_IO_IN);
-
-	fd = accept(rcsd->sk, &saddr, &len);
-	g_assert(fd != -1);
-
-	server_io = g_io_channel_unix_new(fd);
-	g_assert(server_io != NULL);
-
-	/* This causes local impl of _create() to call driver's probe func. */
-	rcsd->cs = ofono_call_settings_create(NULL, OFONO_RIL_VENDOR_AOSP,
-							"rilmodem", rcsd);
-
-	/* add_idle doesn't work, read blocks main loop!!! */
-	g_assert(csd->start_func(rcsd) == FALSE);
-
-	status = g_io_channel_set_encoding(server_io, NULL, NULL);
-	g_assert(status == G_IO_STATUS_NORMAL);
-
-	g_io_channel_set_buffered(server_io, FALSE);
-	g_io_channel_set_close_on_unref(server_io, TRUE);
-
-	rcsd->server_io = server_io;
-
-	g_idle_add(read_server, rcsd);
-
-	/* single-shot callback */
-	return FALSE;
-}
-
-static void create_server_socket(const char *sock_path,
-					struct rilmodemcs_data *rcsd)
-{
-	GIOChannel *io;
-	struct sockaddr_un addr;
-	int retval;
-
-	rcsd->sk = socket(AF_UNIX, SOCK_STREAM, 0);
-	g_assert(rcsd->sk);
-
-	memset(&addr, 0, sizeof(addr));
-	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
-
-	/* Unlink any existing socket for this session */
-	unlink(addr.sun_path);
-
-	retval = bind(rcsd->sk, (struct sockaddr *) &addr, sizeof(addr));
-	g_assert(retval >= 0);
-
-	retval = listen(rcsd->sk, 0);
-	g_assert(retval >= 0);
-
-	io = g_io_channel_unix_new(rcsd->sk);
-	g_assert(io != NULL);
-
-	g_io_channel_set_close_on_unref(io, TRUE);
-	g_io_channel_set_flags(io, G_IO_FLAG_NONBLOCK, NULL);
-
-	rcsd->server_watch = g_io_add_watch_full(io,
-				G_PRIORITY_DEFAULT,
-				G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL,
-				on_socket_connected, rcsd, NULL);
-
-	g_io_channel_unref(io);
-}
-
 /*
  * This unit test:
  *  - does some test data setup
  *  - configures a dummy server socket
- *    - on_socket_connected: callback for
- *      incoming socket connects
  *  - creates a new gril client instance
  *    - triggers a connect to the dummy
  *      server socket
@@ -603,27 +468,29 @@ static void create_server_socket(const char *sock_path,
 static void test_cs_func(gconstpointer data)
 {
 	const struct cs_data *csd = data;
-	struct rilmodemcs_data *rcsd;
+	struct rilmodem_cs_data *rcd;
 
 	ril_call_settings_init();
 
-	rcsd = g_new0(struct rilmodemcs_data, 1);
+	rcd = g_new0(struct rilmodem_cs_data, 1);
 
-	rcsd->test_data = csd;
+	rcd->test_data = csd;
 
-	create_server_socket("/tmp/unittestril", rcsd);
+	rilmodem_test_server_create(&server_connect_cb, &csd->rtd, rcd);
 
-	rcsd->ril = g_ril_new("/tmp/unittestril", OFONO_RIL_VENDOR_AOSP);
-	g_assert(rcsd->ril != NULL);
+	rcd->ril = g_ril_new("/tmp/unittestril", OFONO_RIL_VENDOR_AOSP);
+	g_assert(rcd->ril != NULL);
 
 	mainloop = g_main_loop_new(NULL, FALSE);
 
 	g_main_loop_run(mainloop);
 	g_main_loop_unref(mainloop);
 
-	csdriver->remove(rcsd->cs);
-	g_ril_unref(rcsd->ril);
-	g_free(rcsd);
+	csdriver->remove(rcd->cs);
+	g_ril_unref(rcd->ril);
+	g_free(rcd);
+
+	rilmodem_test_server_close();
 
 	ril_call_settings_exit();
 }

--- a/unit/test-rilmodem-sms.c
+++ b/unit/test-rilmodem-sms.c
@@ -1,0 +1,261 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2015 Canonical Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <glib.h>
+#include <stdio.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <ofono/modem.h>
+#include <ofono/types.h>
+#include <ofono/sms.h>
+#include <gril.h>
+
+#include "common.h"
+#include "ril_constants.h"
+#include "rilmodem-test-server.h"
+
+static GMainLoop *mainloop;
+
+static const struct ofono_sms_driver *smsdriver;
+
+struct rilmodem_sms_data {
+	GRil *ril;
+	struct ofono_modem *modem;
+	gconstpointer test_data;
+	struct ofono_sms *sms;
+};
+
+typedef gboolean (*StartFunc)(gpointer data);
+
+struct sms_data {
+	StartFunc start_func;
+	const struct ofono_phone_number ph;
+	gint param_int1;
+	gint param_int2;
+
+	struct rilmodem_test_data rtd;
+	enum ofono_error_type error_type;
+	gint cb_int1;
+	gint cb_int2;
+};
+
+static void sca_query_callback(const struct ofono_error *error,
+					const struct ofono_phone_number *ph,
+					gpointer data)
+{
+	struct rilmodem_sms_data *rsd = data;
+	const struct sms_data *sd = rsd->test_data;
+
+	g_assert(error->type == sd->error_type);
+
+	if (error->type == OFONO_ERROR_TYPE_NO_ERROR) {
+		g_assert(ph->type == sd->ph.type);
+		g_assert(strcmp(ph->number, sd->ph.number) == 0);
+	}
+
+	g_main_loop_quit(mainloop);
+}
+
+static gboolean trigger_sca_query(gpointer data)
+{
+	struct rilmodem_sms_data *rsd = data;
+
+	g_assert(smsdriver->sca_query != NULL);
+	smsdriver->sca_query(rsd->sms, sca_query_callback, rsd);
+
+	return FALSE;
+}
+
+/* RIL_REQUEST_GET_SMSC_ADDRESS */
+static const guchar req_get_smsc_address_parcel_1[] = {
+	0x00, 0x00, 0x00, 0x08, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+
+/*
+ * RIL_REQUEST_GET_SMSC_ADDRESS reply with the following data:
+ *
+ * {type=145,number=34607003110}
+ */
+static const guchar rsp_get_smsc_address_data_1[] = {
+	0x12, 0x00, 0x00, 0x00, 0x22, 0x00, 0x2b, 0x00, 0x33, 0x00, 0x34, 0x00,
+	0x36, 0x00, 0x30, 0x00, 0x37, 0x00, 0x30, 0x00, 0x30, 0x00, 0x33, 0x00,
+	0x31, 0x00, 0x31, 0x00, 0x30, 0x00, 0x22, 0x00, 0x2c, 0x00, 0x31, 0x00,
+	0x34, 0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static const struct sms_data testdata_sca_query_valid_1 = {
+	.start_func = trigger_sca_query,
+	.ph = { .number = "34607003110", .type = 145 },
+	.rtd = {
+		.req_data = req_get_smsc_address_parcel_1,
+		.req_size = sizeof(req_get_smsc_address_parcel_1),
+		.rsp_data = rsp_get_smsc_address_data_1,
+		.rsp_size = sizeof(rsp_get_smsc_address_data_1),
+		.rsp_error = RIL_E_SUCCESS,
+	},
+	.cb_int1 = 1,
+	.error_type = OFONO_ERROR_TYPE_NO_ERROR,
+};
+
+/* Declarations && Re-implementations of core functions. */
+void ril_sms_exit(void);
+void ril_sms_init(void);
+
+struct ofono_sms {
+	void *driver_data;
+};
+
+struct ofono_sms *ofono_sms_create(struct ofono_modem *modem,
+					unsigned int vendor,
+					const char *driver,
+					void *data)
+{
+	struct rilmodem_sms_data *rsd = data;
+	struct ofono_sms *sms = g_new0(struct ofono_sms, 1);
+	int retval;
+
+	retval = smsdriver->probe(sms, OFONO_RIL_VENDOR_AOSP, rsd->ril);
+	g_assert(retval == 0);
+
+	return sms;
+}
+
+int ofono_sms_driver_register(const struct ofono_sms_driver *d)
+{
+	if (smsdriver == NULL)
+		smsdriver = d;
+
+	return 0;
+}
+
+void ofono_sms_set_data(struct ofono_sms *sms, void *data)
+{
+	sms->driver_data = data;
+}
+
+void *ofono_sms_get_data(struct ofono_sms *sms)
+{
+	return sms->driver_data;
+}
+
+void ofono_sms_register(struct ofono_sms *sms)
+{
+}
+
+void ofono_sms_driver_unregister(const struct ofono_sms_driver *d)
+{
+}
+
+void ofono_sms_deliver_notify(struct ofono_sms *sms, const unsigned char *pdu,
+							int len, int tpdu_len)
+{
+}
+
+void ofono_sms_status_notify(struct ofono_sms *sms, const unsigned char *pdu,
+							int len, int tpdu_len)
+{
+}
+
+static void server_connect_cb(gpointer data)
+{
+	struct rilmodem_sms_data *rsd = data;
+	const struct sms_data *sd = rsd->test_data;
+
+	/* This causes local impl of _create() to call driver's probe func. */
+	rsd->sms = ofono_sms_create(NULL, OFONO_RIL_VENDOR_AOSP,
+							"rilmodem", rsd);
+
+	/* add_idle doesn't work, read blocks main loop!!! */
+	g_assert(sd->start_func(rsd) == FALSE);
+}
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+/*
+ * This unit test:
+ *  - does some test data setup
+ *  - configures a dummy server socket
+ *  - creates a new gril client instance
+ *    - triggers a connect to the dummy
+ *      server socket
+ *  - starts a mainloop
+ */
+static void test_sms_func(gconstpointer data)
+{
+	const struct sms_data *sd = data;
+	struct rilmodem_sms_data *rsd;
+
+	ril_sms_init();
+
+	rsd = g_new0(struct rilmodem_sms_data, 1);
+
+	rsd->test_data = sd;
+
+	rilmodem_test_server_create(&server_connect_cb, &sd->rtd, rsd);
+
+	rsd->ril = g_ril_new(RIL_SERVER_SOCK_PATH, OFONO_RIL_VENDOR_AOSP);
+	g_assert(rsd->ril != NULL);
+
+	mainloop = g_main_loop_new(NULL, FALSE);
+
+	g_main_loop_run(mainloop);
+	g_main_loop_unref(mainloop);
+
+	smsdriver->remove(rsd->sms);
+	g_ril_unref(rsd->ril);
+	g_free(rsd);
+
+	rilmodem_test_server_close();
+
+	ril_sms_exit();
+}
+
+#endif
+
+int main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+
+/*
+ * As all our architectures are little-endian except for
+ * PowerPC, and the Binder wire-format differs slightly
+ * depending on endian-ness, the following guards against test
+ * failures when run on PowerPC.
+ */
+#if BYTE_ORDER == LITTLE_ENDIAN
+	g_test_add_data_func("/testrilmodemsms/sca_query/valid/1",
+					&testdata_sca_query_valid_1,
+					test_sms_func);
+
+#endif
+	return g_test_run();
+}


### PR DESCRIPTION
This change adds new SMS unit tests.  Note, this change required re-factoring rilmodem-test-server, which includes adding support for testing incoming RIL unsolicited replies.

All except the last two commits have been merged upstream.  The last two commits have been submitted, but not yet accepted.