### PR TITLE
unit: fix test-grilreply set_facility_lock test

### DIFF
--- a/unit/test-grilreply.c
+++ b/unit/test-grilreply.c
@@ -1420,7 +1420,7 @@ static const struct query_facility_lock_test
  * RIL_REQUEST_SET_FACILITY_LOCK reply with no parameters.
  */
 static const struct set_facility_lock_test reply_set_facility_lock_valid_1 = {
-	.retries = -1,
+	.retries = 0,
 	.msg = {
 		.buf = NULL,
 		.buf_len = 0,


### PR DESCRIPTION
The reply parsing logic for a SET_FACILITY_LOCK was
re-factored based on upstream changes. One change
made is that the retries return value is now set to
0 for a reply with no data, like done by mako.  This
used to cause a -1 to be returned.  The change ensures
that the 0 is logged if no data is present, and -1
logged if returned by rild.

Note - the caller of the reply parse function discards
the retries return value, so this change is basically
a no-op functionally.