### PR TITLE
Implement wakelock support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ pkginclude_HEADERS = include/log.h include/plugin.h include/history.h \
 			include/cdma-provision.h include/handsfree.h \
 			include/handsfree-audio.h include/siri.h \
 			include/sim-mnclength.h include/spn-table.h \
-			include/dns-client.h
+			include/dns-client.h include/wakelock.h
 
 nodist_pkginclude_HEADERS = include/version.h
 
@@ -641,7 +641,7 @@ src_ofonod_SOURCES = $(builtin_sources) src/ofono.ver \
 			src/handsfree-audio.c src/bluetooth.h \
 			src/hfp.h src/siri.c \
 			src/sim-mnclength.c src/spn-table.c \
-			src/dns-client.c
+			src/dns-client.c src/wakelock.c
 
 src_ofonod_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
 			@GLIB_LIBS@ @DBUS_LIBS@ -ldl

--- a/Makefile.am
+++ b/Makefile.am
@@ -612,6 +612,11 @@ builtin_sources += plugins/push-notification.c
 builtin_modules += smshistory
 builtin_sources += plugins/smshistory.c
 
+if ANDROID_WAKELOCK
+builtin_modules += android_wakelock
+builtin_sources += plugins/android-wakelock.c
+endif
+
 sbin_PROGRAMS = src/ofonod
 
 src_ofonod_SOURCES = $(builtin_sources) src/ofono.ver \

--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,11 @@ AC_ARG_ENABLE(upower, AC_HELP_STRING([--disable-upower],
 					[enable_upower=${enableval}])
 AM_CONDITIONAL(UPOWER, test "${enable_power}" != "no")
 
+AC_ARG_ENABLE(android_wakelock, AC_HELP_STRING([--enable-android-wakelock],
+				[enable Enable support for Android wakelocks]),
+					[enable_android_wakelock=${enableval}])
+AM_CONDITIONAL(ANDROID_WAKELOCK, test "${enable_android_wakelock}" = "yes")
+
 AC_ARG_ENABLE(datafiles, AC_HELP_STRING([--disable-datafiles],
 			[do not install configuration and data files]),
 					[enable_datafiles=${enableval}])

--- a/include/wakelock.h
+++ b/include/wakelock.h
@@ -1,0 +1,100 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2015 Jolla Ltd. All rights reserved.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __OFONO_WAKELOCK_H_
+#define __OFONO_WAKELOCK_H_
+
+#include <ofono/types.h>
+
+/* Wakelock interface
+ *
+ * Wakelocks ensure system does not suspend/enter power save mode
+ * before an ongoing operation completes. This header declares a
+ * wakelock API that can be implemented by a OS-specific plugin.
+ */
+
+struct wakelock; /* Opaque */
+
+struct wakelock_table {
+	int (*create)(const char *name, struct wakelock **);
+	int (*free)(struct wakelock *);
+	int (*acquire)(struct wakelock *);
+	int (*release)(struct wakelock *);
+	ofono_bool_t (*is_locked)(struct wakelock *);
+};
+
+
+/*** Functions for wakelock users ***/
+
+/*
+ * This will create a wakelock which will be held for a short duration
+ * and then automatically freed. If this is called multiple times the
+ * timeout will be restarted on every call.
+ */
+void wakelock_system_lock(void);
+
+/*
+ * Create a wakelock. Multiple wakelocks can be created; if any one of
+ * them is activated, system will be prevented from going to suspend.
+ * This makes it possible to overlap locks to hand over from subsystem
+ * to subsystem, each with their own wakelock-guarded sections,
+ * without falling to suspend in between.
+ */
+int wakelock_create(const char *name, struct wakelock **wakelock);
+
+/*
+ * Free a wakelock, releasing all acquisitions at the same time
+ * and deallocating the lock.
+ */
+int wakelock_free(struct wakelock *wakelock);
+
+/*
+ * Acquire a wakelock. Multiple acquisitions are possible, meaning
+ * that the wakelock needs to be released the same number of times
+ * until it is actually deactivated.
+ */
+int wakelock_acquire(struct wakelock *wakelock);
+
+/*
+ * Release a wakelock, deactivating it if all acquisitions are
+ * released, letting system suspend.
+ */
+int wakelock_release(struct wakelock *wakelock);
+
+/*
+ * Check if a wakelock is currently locked or not.
+ */
+ofono_bool_t wakelock_is_locked(struct wakelock *wakelock);
+
+/*** Functions for wakelock implementors ***/
+
+/*
+ * Register a wakelock implementation. Only one implementation may be
+ * registered at a time. In the absence of an implementation, all
+ * wakelock functions are no-ops.
+ */
+int wakelock_plugin_register(const char *name, struct wakelock_table *fns);
+
+int wakelock_plugin_unregister(void);
+
+#endif

--- a/plugins/android-wakelock.c
+++ b/plugins/android-wakelock.c
@@ -1,0 +1,212 @@
+/*
+ *
+ *  oFono - Open Source Telephony - Android based wakelocks
+ *
+ *  Copyright (C) 2016 Canonical Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <glib.h>
+#include <dlfcn.h>
+
+#include <glib.h>
+
+#define OFONO_API_SUBJECT_TO_CHANGE
+
+#include "plugin.h"
+#include "log.h"
+#include "wakelock.h"
+
+#define ANDROID_WAKELOCK_LOCK_PATH		"/sys/power/wake_lock"
+#define ANDROID_WAKELOCK_UNLOCK_PATH	"/sys/power/wake_unlock"
+
+struct wakelock {
+	char *name;
+	unsigned int acquisitions;
+};
+
+GSList *locks = NULL;
+
+static int file_exists(char const *filename)
+{
+	struct stat st;
+
+	return stat(filename, &st) == 0;
+}
+
+static int write_file(const char *file, const char *content)
+{
+	int fd;
+	unsigned int r = 0;
+
+	fd = open(file, O_WRONLY);
+
+	if (fd == -1)
+		return -EIO;
+
+	r = write(fd, content, strlen(content));
+
+	close(fd);
+
+	if (r != strlen(content))
+		return -EIO;
+
+	return 0;
+}
+
+static int wakelock_lock(const char *name)
+{
+	return write_file(ANDROID_WAKELOCK_LOCK_PATH, name);
+}
+
+static int wakelock_unlock(const char *name)
+{
+	return write_file(ANDROID_WAKELOCK_UNLOCK_PATH, name);
+}
+
+static int android_wakelock_acquire(struct wakelock *lock)
+{
+	if (!lock)
+		return -EINVAL;
+
+	if (lock->acquisitions > 0) {
+		lock->acquisitions++;
+		return 0;
+	}
+
+	if (wakelock_lock(lock->name) < 0)
+		return -EIO;
+
+	lock->acquisitions++;
+
+	return 0;
+}
+
+static int android_wakelock_release(struct wakelock *lock)
+{
+	if (!lock)
+		return -EINVAL;
+
+	DBG("lock %p name %s acquisitions %d",
+		lock, lock->name, lock->acquisitions);
+
+	if (!lock->acquisitions) {
+		ofono_warn("Attempted to release already released lock %s", lock->name);
+		return -EINVAL;
+	}
+
+	if (lock->acquisitions > 1) {
+		lock->acquisitions--;
+		DBG("lock %s released acquisitions %d", lock->name, lock->acquisitions);
+		return 0;
+	}
+
+	if (wakelock_unlock(lock->name) < 0)
+		return -EIO;
+
+	lock->acquisitions = 0;
+
+	DBG("lock %s was released", lock->name);
+
+	return 0;
+}
+
+static int android_wakelock_create(const char *name, struct wakelock **lock)
+{
+	if (!lock)
+		return -EINVAL;
+
+	*lock = g_new0(struct wakelock, 1);
+	(*lock)->name = g_strdup(name);
+	(*lock)->acquisitions = 0;
+
+	locks = g_slist_prepend(locks, *lock);
+
+	DBG("wakelock %s create", name);
+
+	return 0;
+}
+
+static int android_wakelock_free(struct wakelock *lock)
+{
+	if (!lock)
+		return -EINVAL;
+
+	if (lock->acquisitions) {
+		/* Need to force releasing the lock here */
+		lock->acquisitions = 1;
+		android_wakelock_release(lock);
+	}
+
+	locks = g_slist_remove(locks, lock);
+
+	DBG("Freeing lock %s", lock->name);
+
+	g_free(lock->name);
+	g_free(lock);
+
+	return 0;
+}
+
+static ofono_bool_t android_wakelock_is_locked(struct wakelock *lock)
+{
+	if (!lock)
+		return FALSE;
+
+	return lock->acquisitions > 0;
+}
+
+struct wakelock_table driver = {
+	.create = android_wakelock_create,
+	.free = android_wakelock_free,
+	.acquire = android_wakelock_acquire,
+	.release = android_wakelock_release,
+	.is_locked = android_wakelock_is_locked
+};
+
+static int android_wakelock_init(void)
+{
+	if (!file_exists(ANDROID_WAKELOCK_LOCK_PATH)) {
+		ofono_warn("System does not support Android wakelocks.");
+		return 0;
+	}
+
+	if (wakelock_plugin_register("android-wakelock", &driver) < 0) {
+		ofono_error("Failed to register wakelock driver");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static void android_wakelock_exit(void)
+{
+	wakelock_plugin_unregister();
+}
+
+OFONO_PLUGIN_DEFINE(android_wakelock, "Android Wakelock driver", VERSION,
+			OFONO_PLUGIN_PRIORITY_DEFAULT, android_wakelock_init, android_wakelock_exit)

--- a/src/main.c
+++ b/src/main.c
@@ -244,7 +244,11 @@ int main(int argc, char **argv)
 	g_free(option_plugin);
 	g_free(option_noplugin);
 
+	__ofono_wakelock_init();
+
 	g_main_loop_run(event_loop);
+
+	__ofono_wakelock_cleanup();
 
 	__ofono_plugin_cleanup();
 

--- a/src/ofono.h
+++ b/src/ofono.h
@@ -534,3 +534,6 @@ ofono_bool_t __ofono_private_network_request(ofono_private_network_cb_t cb,
 #include <ofono/sim-mnclength.h>
 
 int __ofono_sim_mnclength_get_mnclength(const char *imsi);
+
+int __ofono_wakelock_init(void);
+void __ofono_wakelock_cleanup(void);

--- a/src/voicecall.c
+++ b/src/voicecall.c
@@ -38,6 +38,7 @@
 #include "simutil.h"
 #include "smsutil.h"
 #include "storage.h"
+#include "wakelock.h"
 
 #define MAX_VOICE_CALLS 16
 
@@ -3461,6 +3462,11 @@ static void emulator_atd_cb(struct ofono_emulator *em,
 	size_t len;
 	char number[OFONO_MAX_PHONE_NUMBER_LENGTH + 1];
 	struct ofono_error result;
+
+	/* Make sure we keep the system awake if we get woken up
+	 * shortly for processing the incoming request from the
+	 *  HFP HF. */
+	wakelock_system_lock();
 
 	switch (ofono_emulator_request_get_type(req)) {
 	case OFONO_EMULATOR_REQUEST_TYPE_SET:

--- a/src/wakelock.c
+++ b/src/wakelock.c
@@ -1,0 +1,151 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2015 Jolla Ltd. All rights reserved.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <glib.h>
+
+#include "log.h"
+#include "wakelock.h"
+#include "ofono.h"
+
+#define SYSTEM_WAKELOCK_NAME			"ofono-system"
+#define SYSTEM_WAKELOCK_DURATION		30
+
+static char *impl = NULL;
+static struct wakelock_table table;
+
+static struct wakelock *system_wakelock = NULL;
+static guint system_wakelock_source = 0;
+
+static gboolean system_wakelock_put(gpointer user_data)
+{
+	DBG("Releasing system wakelock");
+	wakelock_release(system_wakelock);
+	system_wakelock_source = 0;
+	return FALSE;
+}
+
+void wakelock_system_lock(void)
+{
+	guint old_source;
+
+	if (!impl)
+		return;
+
+	DBG("Acquiring system wakelock");
+
+	old_source = system_wakelock_source;
+
+	system_wakelock_source = g_timeout_add_seconds(SYSTEM_WAKELOCK_DURATION,
+												system_wakelock_put,
+												NULL);
+	if (system_wakelock_source)
+		wakelock_acquire(system_wakelock);
+
+	if (old_source) {
+		g_source_remove(old_source);
+		wakelock_release(system_wakelock);
+	}
+}
+
+int wakelock_create(const char *name, struct wakelock **wakelock)
+{
+	if (!impl) {
+		*wakelock = NULL;
+		return -EINVAL;
+	}
+
+	return (table.create)(name, wakelock);
+}
+
+int wakelock_free(struct wakelock *wakelock)
+{
+	if (!impl)
+		return -EINVAL;
+
+	return table.free(wakelock);
+}
+
+int wakelock_acquire(struct wakelock *wakelock)
+{
+	if (!impl)
+		return -EINVAL;
+
+	return table.acquire(wakelock);
+}
+
+int wakelock_release(struct wakelock *wakelock)
+{
+	if (!impl)
+		return -EINVAL;
+
+	return table.release(wakelock);
+}
+
+ofono_bool_t wakelock_is_locked(struct wakelock *wakelock) {
+	if (!impl)
+		return -EINVAL;
+
+	return table.is_locked(wakelock);
+}
+
+int wakelock_plugin_register(const char *name, struct wakelock_table *fns)
+{
+	if (impl)
+		return -EALREADY;
+
+	impl = g_strdup(name);
+	memcpy(&table, fns, sizeof(struct wakelock_table));
+	return 0;
+}
+
+int wakelock_plugin_unregister(void)
+{
+	if (!impl)
+		return -ENOENT;
+
+	memset(&table, 0, sizeof(struct wakelock_table));
+	g_free(impl);
+	impl = NULL;
+
+	return 0;
+}
+
+int __ofono_wakelock_init(void)
+{
+	if (wakelock_create(SYSTEM_WAKELOCK_NAME, &system_wakelock) < 0)
+		ofono_warn("Failed to create system keep alive wakelock");
+
+	return 0;
+}
+
+void __ofono_wakelock_cleanup(void)
+{
+	if (system_wakelock)
+		wakelock_free(system_wakelock);
+}


### PR DESCRIPTION
It turned out that when a HFP HF device sends the voice dial command we don't have always enough time until the system goes to sleep again after we did the first steps of processing as we have some kind of different IO things involved in that process. Therefore we acquire the global system wakelock first before doing any further IO to ensure the system stays awake a bit longer until all necessary steps are performed to setup the voicecall where some will acquire additional wakelocks a soon as we have IO activity or created a proper call object on dbus.