### PR TITLE
fix misaligned dual sim behavior compared to AOSP

### DIFF
--- a/plugins/qcom-msim.c
+++ b/plugins/qcom-msim.c
@@ -36,6 +36,18 @@
 
 static int qcom_msim_probe(struct ofono_modem *modem)
 {
+	int slot_id = ofono_modem_get_integer(modem, "Slot");
+
+	/* qcom_msim has socket path "rild", "rild1", ... */
+	if (slot_id != 0) {
+		char *socket;
+
+		socket = g_strdup_printf("/dev/socket/rild%d", slot_id);
+		ofono_modem_set_string(modem, "Socket", socket);
+
+		g_free(socket);
+	}
+
 	return ril_create(modem, OFONO_RIL_VENDOR_QCOM_MSIM);
 }
 

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -74,7 +74,6 @@
 #define RILD_CONNECT_RETRY_TIME_S 5
 
 char *RILD_CMD_SOCKET[] = {"/dev/socket/rild", "/dev/socket/rild1"};
-char *GRIL_HEX_PREFIX[] = {"Device 0: ", "Device 1: "};
 
 struct ril_data {
 	GRil *ril;
@@ -90,9 +89,9 @@ struct ril_data {
 
 static void ril_debug(const char *str, void *user_data)
 {
-	const char *prefix = user_data;
+	struct ril_data *rd = user_data;
 
-	ofono_info("%s%s", prefix, str);
+	ofono_info("Device %d: %s", g_ril_get_slot(rd->ril), str);
 }
 
 static void ril_radio_state_changed(struct ril_msg *message, gpointer user_data)
@@ -377,7 +376,7 @@ static int create_gril(struct ofono_modem *modem)
 		g_ril_set_trace(rd->ril, TRUE);
 
 	if (getenv("OFONO_RIL_HEX_TRACE"))
-		g_ril_set_debugf(rd->ril, ril_debug, GRIL_HEX_PREFIX[slot_id]);
+		g_ril_set_debugf(rd->ril, ril_debug, rd);
 
 	g_ril_register(rd->ril, RIL_UNSOL_RIL_CONNECTED,
 			ril_connected, modem);

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -73,8 +73,6 @@
 #define RILD_MAX_CONNECT_RETRIES 5
 #define RILD_CONNECT_RETRY_TIME_S 5
 
-char *RILD_CMD_SOCKET[] = {"/dev/socket/rild", "/dev/socket/rild1"};
-
 struct ril_data {
 	GRil *ril;
 	enum ofono_ril_vendor vendor;
@@ -353,10 +351,10 @@ static int create_gril(struct ofono_modem *modem)
 {
 	struct ril_data *rd = ofono_modem_get_data(modem);
 	int slot_id = ofono_modem_get_integer(modem, "Slot");
+	const gchar *socket = ofono_modem_get_string(modem, "Socket");
 
-	ofono_info("Using %s as socket for slot %d.",
-					RILD_CMD_SOCKET[slot_id], slot_id);
-	rd->ril = g_ril_new(RILD_CMD_SOCKET[slot_id], rd->vendor);
+	ofono_info("Using %s as socket for slot %d.", socket, slot_id);
+	rd->ril = g_ril_new(socket, rd->vendor);
 
 	/* NOTE: Since AT modems open a tty, and then call
 	 * g_at_chat_new(), they're able to return -EIO if

--- a/plugins/rildev.c
+++ b/plugins/rildev.c
@@ -43,6 +43,7 @@ static int create_rilmodem(const char *ril_type, int slot)
 {
 	struct ofono_modem *modem;
 	char dev_name[64];
+	char *socket;
 	int retval;
 
 	snprintf(dev_name, sizeof(dev_name), "ril_%d", slot);
@@ -57,6 +58,15 @@ static int create_rilmodem(const char *ril_type, int slot)
 	modem_list = g_slist_prepend(modem_list, modem);
 
 	ofono_modem_set_integer(modem, "Slot", slot);
+
+	/* AOSP has socket path "rild", "rild2"..., while others may differ */
+	if (slot != 0)
+		socket = g_strdup_printf("/dev/socket/rild%d", slot + 1);
+	else
+		socket = g_strdup("/dev/socket/rild");
+
+	ofono_modem_set_string(modem, "Socket", socket);
+	g_free(socket);
 
 	/* This causes driver->probe() to be called... */
 	retval = ofono_modem_register(modem);


### PR DESCRIPTION
Two things addressed in this pull request. One commit for each.

This first thing is ril daemon socket path for the 2nd instance should be _/dev/socket/rild2_ instead of _/dev/socket/rild1_. See https://android.googlesource.com/platform/hardware/ril/+/android-5.0.0_r1/libril/ril.cpp#59

The other thing is some rild implementation issues radio state change event with state __UNAVAILABLE__ after __RIL_CONNECTED__. After that, rild is expecting a reset by __RADIO_POWER__ request to __OFF__. This is actually etched in Android telephony framework and for aforementioned ril implementations, they simply cannot transit its internal state to on without such reset. See https://android.googlesource.com/platform/frameworks/opt/telephony/+/android-5.1.1_r1/src/java/com/android/internal/telephony/RIL.java#3115 and http://git.mozilla.org/?p=releases/gecko.git;a=blob;f=dom/system/gonk/ril_worker.js;h=330030036500b0ecc44473738ddb78d8171936a4;hb=HEAD#l5333