### PR TITLE
build: fix -Werror=type-limits

### DIFF
--- a/unit/test-grilreply.c
+++ b/unit/test-grilreply.c
@@ -1686,7 +1686,7 @@ static void test_reply_call_fail_cause_valid(gconstpointer data)
 
 	reason = g_ril_reply_parse_call_fail_cause(NULL, data);
 
-	g_assert(reason >= 0);
+	g_assert(reason == OFONO_DISCONNECT_REASON_REMOTE_HANGUP);
 }
 
 static void test_reply_get_mute_off(gconstpointer data)


### PR DESCRIPTION
unit/test-grilreply.c: In function 'test_reply_call_fail_cause_valid':
unit/test-grilreply.c:1689:2: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]
cc1: all warnings being treated as errors
Makefile:3667: recipe for target 'unit/test-grilreply.o' failed
make[1]: *** [unit/test-grilreply.o] Error 1
make[1]: *** Waiting for unfinished jobs....
Makefile:2030: recipe for target 'all' failed
make: *** [all] Error 2