### PR TITLE
Fix for lp1533508

### DIFF
--- a/drivers/rilmodem/gprs.c
+++ b/drivers/rilmodem/gprs.c
@@ -336,12 +336,9 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 		}
 	}
 
-	if (gd->tech != reply->reg_state.tech) {
-		gd->tech = reply->reg_state.tech;
-
-		ofono_gprs_bearer_notify(gprs,
+	gd->tech = reply->reg_state.tech;
+	ofono_gprs_bearer_notify(gprs,
 				ril_tech_to_bearer_tech(reply->reg_state.tech));
-	}
 
 	if (cb)
 		CALLBACK_WITH_SUCCESS(cb, reply->reg_state.status, cbd->data);

--- a/src/gprs.c
+++ b/src/gprs.c
@@ -1703,6 +1703,12 @@ static void gprs_attached_update(struct ofono_gprs *gprs)
 		release_active_contexts(gprs);
 		gprs->bearer = -1;
 	} else if (have_active_contexts(gprs) == TRUE) {
+		/*
+		 * Some times the context activates after a detach event and
+		 * right before an attach. We close it to avoid unexpected open
+		 * contexts.
+		 */
+		release_active_contexts(gprs);
 		gprs->flags |= GPRS_FLAG_ATTACHED_UPDATE;
 		return;
 	}


### PR DESCRIPTION
In some cases it is possible that a context is opened after a detach event has been received, and right before an attach, depending on the modem. We can sure that those contexts are removed to keep consistency. Fixes LP: #1533508.