### PR TITLE
ril: allow entering low power state with no SIM

### DIFF
--- a/drivers/rilmodem/gprs.c
+++ b/drivers/rilmodem/gprs.c
@@ -188,21 +188,25 @@ static void gprs_allow_data_cb(struct ril_msg *message, gpointer user_data)
 	struct gprs_attach_data *attach_data = cbd->user;
 	struct ril_gprs_data *gd = attach_data->gd;
 
-	if (message->error != RIL_E_SUCCESS) {
-		ofono_error("%s: RIL error %s", __func__,
-				ril_error_to_string(message->error));
-		CALLBACK_WITH_FAILURE(cb, cbd->data);
-		free_attach_cbd(cbd);
-		return;
-	}
-
 	g_ril_print_response_no_args(attach_data->ril, message);
 
+	/*
+	 * We do not care if detaching the other slot fails. This happens in
+	 * turbo when the other slot is empty, for instance.
+	 */
 	if (attach_data->detaching_other_slot) {
 		attach_data->ril = gd->ril;
 		attach_data->detaching_other_slot = FALSE;
 
 		send_allow_data(cbd, gd->ril, attach_data->set_attached);
+		return;
+	}
+
+	if (message->error != RIL_E_SUCCESS) {
+		ofono_error("%s: RIL error %s", __func__,
+				ril_error_to_string(message->error));
+		CALLBACK_WITH_FAILURE(cb, cbd->data);
+		free_attach_cbd(cbd);
 		return;
 	}
 

--- a/drivers/rilmodem/radio-settings.c
+++ b/drivers/rilmodem/radio-settings.c
@@ -290,10 +290,14 @@ void ril_delayed_register(const struct ofono_error *error, void *user_data)
 {
 	struct ofono_radio_settings *rs = user_data;
 
-	if (error->type == OFONO_ERROR_TYPE_NO_ERROR)
-		ofono_radio_settings_register(rs);
-	else
+	if (error->type != OFONO_ERROR_TYPE_NO_ERROR)
 		ofono_error("%s: cannot set default fast dormancy", __func__);
+
+	/*
+	 * We register in all cases, setting FD some times fails until radio is
+	 * available (this happens on turbo and maybe in other devices).
+	 */
+	ofono_radio_settings_register(rs);
 }
 
 static int ril_radio_settings_probe(struct ofono_radio_settings *rs,

--- a/plugins/ril.c
+++ b/plugins/ril.c
@@ -286,6 +286,7 @@ void ril_pre_sim(struct ofono_modem *modem)
 	struct ril_data *rd = ofono_modem_get_data(modem);
 	struct ril_voicecall_driver_data vc_data = { rd->ril, modem };
 	struct ril_sim_data sim_data;
+	struct ril_radio_settings_driver_data rs_data = { rd->ril, modem };
 
 	DBG("");
 
@@ -305,6 +306,16 @@ void ril_pre_sim(struct ofono_modem *modem)
 
 	rd->sim = ofono_sim_create(modem, rd->vendor,
 			get_driver_type(rd, OFONO_ATOM_TYPE_SIM), &sim_data);
+
+	/*
+	 * We need to create radio settings here so FastDormancy property is
+	 * available even when there is no SIM (no SIM -> post_sim and
+	 * post_online are not called) so we can make the modem enter low power
+	 * state in that case.
+	 */
+	ofono_radio_settings_create(modem, rd->vendor,
+			get_driver_type(rd, OFONO_ATOM_TYPE_RADIO_SETTINGS),
+			&rs_data);
 }
 
 void ril_post_sim(struct ofono_modem *modem)
@@ -328,16 +339,12 @@ static void create_post_online_atoms(struct ofono_modem *modem)
 	struct ril_data *rd = ofono_modem_get_data(modem);
 	struct ofono_gprs *gprs;
 	struct ofono_gprs_context *gc;
-	struct ril_radio_settings_driver_data rs_data = { rd->ril, modem };
 	struct ril_gprs_driver_data gprs_data = { rd->ril, modem };
 	struct ril_gprs_context_data
 		inet_ctx = { rd->ril, modem, OFONO_GPRS_CONTEXT_TYPE_INTERNET };
 	struct ril_gprs_context_data
 		mms_ctx = { rd->ril, modem, OFONO_GPRS_CONTEXT_TYPE_MMS };
 
-	ofono_radio_settings_create(modem, rd->vendor,
-			get_driver_type(rd, OFONO_ATOM_TYPE_RADIO_SETTINGS),
-			&rs_data);
 	ofono_netreg_create(modem, rd->vendor,
 			get_driver_type(rd, OFONO_ATOM_TYPE_NETREG), rd->ril);
 	ofono_ussd_create(modem, rd->vendor,


### PR DESCRIPTION
Create radio settings atom in pre-sim state so we can set FastDormancy and enter low power state even when there is no SIM.