### PR TITLE
voicecall: add emergency numbers required for China Market.

### DIFF
--- a/src/voicecall.c
+++ b/src/voicecall.c
@@ -118,7 +118,7 @@ struct emulator_status {
 
 static const char *default_en_list[] = { "911", "112", NULL };
 static const char *default_en_list_no_sim[] = { "119", "118", "999", "110",
-						"08", "000", NULL };
+					"08", "000", "120", "122", NULL };
 
 static void send_ciev_after_swap_callback(const struct ofono_error *error,
 								void *data);
@@ -2504,10 +2504,6 @@ static void set_new_ecc(struct ofono_voicecall *vc)
 	vc->en_list = g_hash_table_new_full(g_str_hash, g_str_equal,
 							g_free, NULL);
 
-	/* Emergency numbers from modem/network */
-	if (vc->nw_en_list)
-		add_to_en_list(vc, vc->nw_en_list);
-
 	/* Emergency numbers read from SIM */
 	if (vc->flags & VOICECALL_FLAG_SIM_ECC_READY) {
 		GSList *l;
@@ -2515,8 +2511,15 @@ static void set_new_ecc(struct ofono_voicecall *vc)
 		for (l = vc->sim_en_list; l; l = l->next)
 			g_hash_table_insert(vc->en_list, g_strdup(l->data),
 							NULL);
-	} else
+	}
+
+	/* add the default emergency number, if there no number from SIM */
+	if (g_hash_table_size(vc->en_list) == 0)
 		add_to_en_list(vc, (char **) default_en_list_no_sim);
+
+	/* Emergency numbers from modem/network */
+	if (vc->nw_en_list)
+		add_to_en_list(vc, vc->nw_en_list);
 
 	/* Default emergency numbers */
 	add_to_en_list(vc, (char **) default_en_list);


### PR DESCRIPTION
- China telecom regulation required to have 110,119,120,122 as emergency call number.
- In 3GPP TS 51.010-1 (GSM) and 3GPP 34.123-1 (WCDMA) Section 13.2.1
  The following emergency numbers shall be stored in the UE for use without USIM:
  000, 08, 112, 110, 118, 119, 911 and 999.
- In 3GPP TS 51.010-1 (GSM) Section 26.9.6
  When no emergency numbers are stored within the SIM/USIM the following numbers shall
  be stored in the ME for use as emergency numbers: 112, and 911.
- Tested on China Mobile USIM Card, it has 4 records of emergency numbers, but all
  empty string. It shall use the default non-SIM numbers.
- Tested two other operators in Taipei (CHT and TWN), both have empty record.
