### PR TITLE
backport fixes to make the modem remember the settings

### DIFF
--- a/drivers/rilmodem/radio-settings.c
+++ b/drivers/rilmodem/radio-settings.c
@@ -513,6 +513,7 @@ static void ril_rat_mode_cb(struct ril_msg *message, gpointer user_data)
 	 */
 
 	switch (pref) {
++       case PREF_NET_TYPE_WCDMA:
 	case PREF_NET_TYPE_GSM_WCDMA:
 	case PREF_NET_TYPE_GSM_WCDMA_AUTO:
 		mode = OFONO_RADIO_ACCESS_MODE_UMTS;


### PR DESCRIPTION
This backports two commits from upstream ofono in order to fix this bug: https://bugs.launchpad.net/ubuntu/+source/ubuntu-system-settings/+bug/1613327

