### PR TITLE
RESUME_REGISTRATION reply for mtk2 plugin (Still not working)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -169,7 +169,8 @@ builtin_sources += drivers/mtk2modem/mtk2modem.h \
 			drivers/mtk2modem/mtk2util.h \
 			drivers/mtk2modem/mtk2util.c \
 			drivers/mtk2modem/voicecall.c \
-			drivers/mtk2modem/gprs.c
+			drivers/mtk2modem/gprs.c \
+			drivers/mtk2modem/network-registration.c
 
 builtin_modules += rilmodem
 builtin_sources += drivers/rilmodem/rilmodem.h \

--- a/drivers/mtk2modem/mtk2modem.c
+++ b/drivers/mtk2modem/mtk2modem.c
@@ -39,7 +39,8 @@ static int mtk2modem_init(void)
 
 	mtk2_voicecall_init();
 	mtk2_gprs_init();
-
+	mtk2_netreg_init();
+	
 	return 0;
 }
 
@@ -49,6 +50,7 @@ static void mtk2modem_exit(void)
 
 	mtk2_voicecall_exit();
 	mtk2_gprs_exit();
+	mtk2_netreg_exit();
 }
 
 OFONO_PLUGIN_DEFINE(mtk2modem, "MTK2 modem driver", VERSION,

--- a/drivers/mtk2modem/mtk2modem.h
+++ b/drivers/mtk2modem/mtk2modem.h
@@ -26,3 +26,6 @@ extern void mtk2_voicecall_exit(void);
 
 extern void mtk2_gprs_init(void);
 extern void mtk2_gprs_exit(void);
+
+extern void mtk2_netreg_init(void);
+extern void mtk2_netreg_exit(void);

--- a/drivers/mtk2modem/network-registration.c
+++ b/drivers/mtk2modem/network-registration.c
@@ -1,0 +1,146 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <glib.h>
+
+#include <ofono/log.h>
+#include <ofono/modem.h>
+#include <ofono/netreg.h>
+#include <ofono/spn-table.h>
+
+#include "common.h"
+#include "gril.h"
+
+#include "grilreply.h"
+#include "grilrequest.h"
+#include "grilunsol.h"
+#include <ofono/netreg.h>
+#include "drivers/rilmodem/network-registration.h"
+#include "mtk2_constants.h"
+#include "mtk2modem.h"
+#include "drivers/mtkmodem/mtkunsol.h"
+#include "drivers/mtkmodem/mtkrequest.h"
+#include "src/ofono.h"
+#include "plugins/ril.h"
+
+struct ril_data {
+	GRil *ril;
+	enum ofono_ril_vendor vendor;
+	int sim_status_retries;
+	ofono_bool_t init_state;
+	ofono_bool_t ofono_online;
+	int radio_state;
+	struct ofono_sim *sim;
+	int rild_connect_retries;
+	GRilMsgIdToStrFunc request_id_to_string;
+	GRilMsgIdToStrFunc unsol_request_to_string;
+	ril_get_driver_type_func get_driver_type;
+	struct cb_data *set_online_cbd;
+};
+
+static void mtk2_reg_suspended_cb(struct ril_msg *message, gpointer user_data)
+{
+	struct ofono_modem *modem = user_data;
+	struct ril_data *md = ofono_modem_get_data(modem);
+
+	if (message->error != RIL_E_SUCCESS) {
+		ofono_error("%s: RIL error %s", __func__,
+				ril_error_to_string(message->error));
+		return;
+	}
+
+	g_ril_print_response_no_args(md->ril, message);
+}
+
+static void mtk2_reg_suspended(struct ril_msg *message, gpointer user_data)
+{
+	struct ofono_modem *modem = user_data;
+	struct ril_data *md = ofono_modem_get_data(modem);
+	struct parcel rilp;
+	int session_id;
+
+	session_id = g_mtk_unsol_parse_registration_suspended(md->ril, message);
+	if (session_id < 0) {
+		ofono_error("%s: parse error", __func__);
+		return;
+	}
+
+	g_mtk_request_resume_registration(md->ril, session_id, &rilp);
+
+	if (g_ril_send(md->ril, MTK2_RIL_REQUEST_RESUME_REGISTRATION, &rilp,
+			mtk2_reg_suspended_cb, modem, NULL) == 0)
+		ofono_error("%s: failure sending request", __func__);
+}
+
+static gboolean mtk2_delayed_register(gpointer user_data)
+{
+	struct ofono_netreg *netreg = user_data;
+	struct netreg_data *nd = ofono_netreg_get_data(netreg);
+				
+	g_ril_register(nd->ril, MTK2_RIL_UNSOL_RESPONSE_REGISTRATION_SUSPENDED,
+			mtk2_reg_suspended, netreg);
+
+	/* This makes the timeout a single-shot */
+	return FALSE;
+}
+
+static int mtk2_netreg_probe(struct ofono_netreg *netreg, unsigned int vendor,
+				void *data)
+{
+	GRil *ril = data;
+	struct netreg_data *nd;
+
+	nd = g_new0(struct netreg_data, 1);
+
+	nd->ril = g_ril_clone(ril);
+	nd->vendor = vendor;
+	nd->tech = RADIO_TECH_UNKNOWN;
+	nd->time.sec = -1;
+	nd->time.min = -1;
+	nd->time.hour = -1;
+	nd->time.mday = -1;
+	nd->time.mon = -1;
+	nd->time.year = -1;
+	nd->time.dst = 0;
+	nd->time.utcoff = 0;
+	ofono_netreg_set_data(netreg, nd);
+
+	/*
+	 * ofono_netreg_register() needs to be called after
+	 * the driver has been set in ofono_netreg_create(),
+	 * which calls this function.  Most other drivers make
+	 * some kind of capabilities query to the modem, and then
+	 * call register in the callback; we use the idle loop here.
+	 */
+	g_idle_add(mtk2_delayed_register, netreg);
+
+	return 0;
+}
+
+static struct ofono_netreg_driver driver = {
+	.name				= MTK2MODEM,
+	.probe				= mtk2_netreg_probe,
+	.remove				= ril_netreg_remove,
+	.registration_status		= ril_registration_status,
+	.current_operator		= ril_current_operator,
+	.list_operators			= ril_list_operators,
+	.register_auto			= ril_register_auto,
+	.register_manual		= ril_register_manual,
+	.strength			= ril_signal_strength,
+};
+
+void mtk2_netreg_init(void)
+{
+	ofono_netreg_driver_register(&driver);
+}
+
+void mtk2_netreg_exit(void)
+{
+	ofono_netreg_driver_unregister(&driver);
+}

--- a/drivers/rilmodem/network-registration.h
+++ b/drivers/rilmodem/network-registration.h
@@ -1,0 +1,48 @@
+#ifndef __OFONO_NETWORK_REG_H
+#define __OFONO_NETWORK_REG_H
+
+struct netreg_data {
+	GRil *ril;
+	char mcc[OFONO_MAX_MCC_LENGTH + 1];
+	char mnc[OFONO_MAX_MNC_LENGTH + 1];
+	int signal_index; /* If strength is reported via CIND */
+	int signal_min; /* min strength reported via CIND */
+	int signal_max; /* max strength reported via CIND */
+	int signal_invalid; /* invalid strength reported via CIND */
+	int tech;
+	struct ofono_network_time time;
+	guint nitz_timeout;
+	unsigned int vendor;
+};
+
+void ril_registration_status(struct ofono_netreg *netreg,
+					ofono_netreg_status_cb_t cb,
+					void *data);
+
+
+void ril_current_operator(struct ofono_netreg *netreg,
+				ofono_netreg_operator_cb_t cb, void *data);
+				
+void ril_list_operators(struct ofono_netreg *netreg,
+				ofono_netreg_operator_list_cb_t cb, void *data);
+				
+void ril_netreg_remove(struct ofono_netreg *netreg);
+
+void ril_register_auto(struct ofono_netreg *netreg,
+				ofono_netreg_register_cb_t cb, void *data);
+
+void ril_register_manual(struct ofono_netreg *netreg,
+				const char *mcc, const char *mnc,
+				ofono_netreg_register_cb_t cb, void *data);
+				
+void ril_signal_strength(struct ofono_netreg *netreg,
+				ofono_netreg_strength_cb_t cb, void *data);
+				
+void ril_nitz_notify(struct ril_msg *message, gpointer user_data);
+
+void ril_strength_notify(struct ril_msg *message, gpointer user_data);
+
+void ril_network_state_change(struct ril_msg *message,
+							gpointer user_data);
+
+#endif

--- a/plugins/mtk2.c
+++ b/plugins/mtk2.c
@@ -43,6 +43,7 @@ static const char *mtk2_get_driver_type(enum ofono_atom_type atom)
 	switch (atom) {
 	case OFONO_ATOM_TYPE_VOICECALL:
 	case OFONO_ATOM_TYPE_GPRS:
+	case OFONO_ATOM_TYPE_NETREG:
 		return MTK2MODEM;
 	default:
 		return RILMODEM;


### PR DESCRIPTION
Trying to send RESUME_REGISTRATION reply to REGISTRATION_SUSPENDED unsol request in mtk2 driver.
I followed the scheme used by the voicecall atom for the same plugin, and took the code for specific functions from the analogous patch for mtk(1) plugin:
https://github.com/rilmodem/ofono/commit/2c83eb87980b08435b072ab4209030c192ad354d

No luck. Keep in mind that the patch for the old plugin uses a socket created by create_gril() inside mtk.c directly. I tried to use delayed_register() instead, overriding network-registration.c.